### PR TITLE
Fix: Attribution Mentions and Quality Context

### DIFF
--- a/src/personas/quality.ts
+++ b/src/personas/quality.ts
@@ -46,13 +46,21 @@ Maintain a professional, critical but constructive, and high-quality-oriented ap
                 context += "\nUse [RUN: cat <file>] to review specific file contents from the PR.";
             } 
             
-            context += "\n\n--- ENVIRONMENT ---\nYou are in a Nix-based VM. Use [RUN: ls -R] or [RUN: find src] to explore the repository state.";
+            context += "\n\n--- CURRENT REPOSITORY STATE (Source Files) ---\n";
+            const repoFiles = await this.github.getFilesRecursive(owner, repo, 'src');
+            for (const file of repoFiles) {
+                // Filter for source files to keep context manageable
+                if (file.path.endsWith('.ts') || file.path.endsWith('.js') || file.path.endsWith('.md')) {
+                    context += `\n--- File: ${file.path} ---\n`;
+                    context += file.content + '\n';
+                }
+            }
 
         } catch (error) {
-            context += `\nError gathering PR context: ${error instanceof Error ? error.message : String(error)}`;
+            context += `\nError gathering repository context: ${error instanceof Error ? error.message : String(error)}`;
         }
 
-        const userMessage = "A quality review has been requested. Please review the implementation provided in the context and explore the repository as needed to ensure it meets project standards.";
+        const userMessage = "A quality review has been requested. Please review the implementation and the overall repository state provided in the context above against the project requirements and engineering standards.";
 
         const response = await this.gemini.promptPersona(
             QualityPersona.SYSTEM_INSTRUCTION,

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -6,7 +6,7 @@ export class PersonaHelper {
         issueNumber: number,
         commenter?: string
     ): string {
-        const responderContext = commenter ? `a comment from @${commenter} on issue #${issueNumber}` : `issue #${issueNumber}`;
+        const responderContext = commenter ? `a comment from ${commenter} on issue #${issueNumber}` : `issue #${issueNumber}`;
         return `I am the ${personaName}, and I am responding to ${responderContext}.\n\n`;
     }
 


### PR DESCRIPTION
Removes @mentions from attribution strings to prevent accidental persona triggers and restores the Quality persona's ability to inspect the full repository state.