### PR TITLE
[codex] Instrument Gemini persona execution path for comparison

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -10,6 +10,13 @@ import { GitHubService } from "./utils/github.js";
 import { getAttribution } from "./utils/persona_helper.js";
 import { ShellService } from "./utils/shell.js";
 import { truncate } from "./utils/text.js";
+import {
+	logTrace,
+	makeTraceId,
+	runWithTraceContext,
+	type TraceContext,
+	textStats,
+} from "./utils/trace.js";
 
 async function run() {
 	const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -35,6 +42,14 @@ async function run() {
 
 	const sender = eventData.sender?.login;
 	const botUser = "anicolao"; // The identity used by OVERSEER_TOKEN
+	logTrace("dispatcher.start", {
+		eventName,
+		sender,
+		runId: process.env.GITHUB_RUN_ID,
+		nodeVersion: process.version,
+		hasGeminiApiKey: geminiApiKey.length > 0,
+		hasGithubToken: githubToken.length > 0,
+	});
 
 	console.log(`Received GitHub event: ${eventName} from ${sender}`);
 
@@ -85,16 +100,38 @@ async function run() {
 	let executedPersona: string | null = null;
 	let commentUrl: string | undefined;
 	let senderPersona: string | undefined;
+	let traceContext: TraceContext | undefined;
 
 	if (eventName === "issues" && eventData.action === "opened") {
-		iterationResult = await personas.overseer.handleNewIssue(
+		executedPersona = "overseer";
+		traceContext = {
+			traceId: makeTraceId({
+				runId: process.env.GITHUB_RUN_ID,
+				persona: executedPersona,
+				issueNumber,
+			}),
+			persona: executedPersona,
 			owner,
 			repo,
 			issueNumber,
-			eventData.issue.title,
-			eventData.issue.body || "",
-		);
-		executedPersona = "overseer";
+			runId: process.env.GITHUB_RUN_ID,
+			eventName,
+			sender,
+		};
+		iterationResult = await runWithTraceContext(traceContext, async () => {
+			logTrace("dispatcher.persona.dispatch", {
+				trigger: "issues.opened",
+				title: textStats(eventData.issue.title),
+				body: textStats(eventData.issue.body || ""),
+			});
+			return personas.overseer.handleNewIssue(
+				owner,
+				repo,
+				issueNumber,
+				eventData.issue.title,
+				eventData.issue.body || "",
+			);
+		});
 	} else if (eventName === "issue_comment" && eventData.action === "created") {
 		const body = eventData.comment.body as string;
 		commentUrl = eventData.comment.html_url as string;
@@ -147,6 +184,22 @@ async function run() {
 		}
 
 		if (shouldExecute && executedPersona) {
+			traceContext = {
+				traceId: makeTraceId({
+					runId: process.env.GITHUB_RUN_ID,
+					persona: executedPersona,
+					issueNumber,
+				}),
+				persona: executedPersona,
+				owner,
+				repo,
+				issueNumber,
+				runId: process.env.GITHUB_RUN_ID,
+				eventName,
+				sender,
+				commentUrl,
+				senderPersona,
+			};
 			// 4. Persona-Specific Bot Protection: Prevent self-triggering
 			if (
 				sender === botUser &&
@@ -158,62 +211,86 @@ async function run() {
 
 			console.log(`Executing persona: ${executedPersona}`);
 			try {
-				if (executedPersona === "overseer") {
-					iterationResult = await personas.overseer.handleComment(
-						owner,
-						repo,
-						issueNumber,
-						sender,
-						body,
-						commentUrl,
-						senderPersona,
-					);
-				} else if (executedPersona === "product-architect") {
-					iterationResult = await personas.productArchitect.handleMention(
-						owner,
-						repo,
-						issueNumber,
-						sender,
-						body,
-						commentUrl,
-						senderPersona,
-					);
-				} else if (executedPersona === "planner") {
-					iterationResult = await personas.planner.handleMention(
-						owner,
-						repo,
-						issueNumber,
-						sender,
-						body,
-						commentUrl,
-						senderPersona,
-					);
-				} else if (executedPersona === "developer-tester") {
-					iterationResult = await personas.developerTester.handleTask(
-						owner,
-						repo,
-						issueNumber,
-						body,
-						commentUrl,
-						senderPersona,
-					);
-				} else if (executedPersona === "quality") {
-					const prMatch =
-						body.match(/PR.*?#(\d+)/i) || body.match(/pull.*?\/(\d+)/i);
-					const prNumber = prMatch ? Number.parseInt(prMatch[1], 10) : 0;
-					iterationResult = await personas.quality.handleReviewRequest(
-						owner,
-						repo,
-						issueNumber,
-						prNumber,
-						sender,
-						commentUrl,
-						senderPersona,
-					);
-				}
-			} catch (error) {
-				console.error(`Persona failed: ${executedPersona}`, error);
-				iterationResult = {
+				iterationResult = await runWithTraceContext(traceContext, async () => {
+					logTrace("dispatcher.persona.dispatch", {
+						trigger: "issue_comment.created",
+						activePersona,
+						targetedPersona,
+						body: textStats(body),
+					});
+
+					if (executedPersona === "overseer") {
+						return personas.overseer.handleComment(
+							owner,
+							repo,
+							issueNumber,
+							sender,
+							body,
+							commentUrl,
+							senderPersona,
+						);
+					}
+					if (executedPersona === "product-architect") {
+						return personas.productArchitect.handleMention(
+							owner,
+							repo,
+							issueNumber,
+							sender,
+							body,
+							commentUrl,
+							senderPersona,
+						);
+					}
+					if (executedPersona === "planner") {
+						return personas.planner.handleMention(
+							owner,
+							repo,
+							issueNumber,
+							sender,
+							body,
+							commentUrl,
+							senderPersona,
+						);
+					}
+					if (executedPersona === "developer-tester") {
+						return personas.developerTester.handleTask(
+							owner,
+							repo,
+							issueNumber,
+							body,
+							commentUrl,
+							senderPersona,
+						);
+					}
+					if (executedPersona === "quality") {
+						const prMatch =
+							body.match(/PR.*?#(\d+)/i) || body.match(/pull.*?\/(\d+)/i);
+						const prNumber = prMatch ? Number.parseInt(prMatch[1], 10) : 0;
+						logTrace("dispatcher.quality.prInference", {
+							body: textStats(body),
+							prNumber,
+						});
+						return personas.quality.handleReviewRequest(
+							owner,
+							repo,
+							issueNumber,
+							prNumber,
+							sender,
+							commentUrl,
+							senderPersona,
+						);
+					}
+					return null;
+				});
+				} catch (error) {
+					console.error(`Persona failed: ${executedPersona}`, error);
+					await runWithTraceContext(traceContext, async () => {
+						logTrace("dispatcher.persona.error", {
+							error:
+								error instanceof Error ? error.stack || error.message : error,
+						});
+					});
+					iterationResult = {
 					finalResponse: `ERROR: Execution failed. Details: ${error instanceof Error ? error.message : String(error)}`,
 					log: `CRITICAL ERROR: ${error}`,
 				};
@@ -222,20 +299,44 @@ async function run() {
 	}
 
 	if (iterationResult && executedPersona) {
-		await finalizeRun(
-			github,
-			shell,
-			owner,
-			repo,
-			issueNumber,
-			executedPersona,
-			iterationResult,
-			handleMap,
-			personaNameMap,
-			sender,
-			commentUrl,
-			senderPersona,
-		);
+		const finalTraceContext =
+			traceContext ||
+			({
+				traceId: makeTraceId({
+					runId: process.env.GITHUB_RUN_ID,
+					persona: executedPersona,
+					issueNumber,
+				}),
+				persona: executedPersona,
+				owner,
+				repo,
+				issueNumber,
+				runId: process.env.GITHUB_RUN_ID,
+				eventName,
+				sender,
+				commentUrl,
+				senderPersona,
+			} satisfies TraceContext);
+		await runWithTraceContext(finalTraceContext, async () => {
+			logTrace("dispatcher.finalize.begin", {
+				finalResponse: textStats(iterationResult?.finalResponse || ""),
+				log: textStats(iterationResult?.log || ""),
+			});
+			await finalizeRun(
+				github,
+				shell,
+				owner,
+				repo,
+				issueNumber,
+				executedPersona,
+				iterationResult,
+				handleMap,
+				personaNameMap,
+				sender,
+				commentUrl,
+				senderPersona,
+			);
+		});
 	}
 }
 

--- a/src/personas/developer_tester.ts
+++ b/src/personas/developer_tester.ts
@@ -2,6 +2,7 @@ import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
+import { logTrace, textStats } from "../utils/trace.js";
 
 export class DeveloperTesterPersona {
 	private gemini: GeminiService;
@@ -45,6 +46,12 @@ You are authorized to modify any file in the repository using standard Unix tool
 			issueNumber,
 		);
 		const initialMessage = `The Overseer has tasked you with implementation: ${taskDescription}\n\nPlease proceed with the Plan-Act-Verify cycle in the repository.`;
+		logTrace("persona.developerTester.promptPrepared", {
+			taskDescription: textStats(taskDescription),
+			initialMessage: textStats(initialMessage),
+			fullContext: textStats(fullContext),
+			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -3,6 +3,7 @@ import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
 import { isLimitReached } from "../utils/persona_helper.js";
+import { logTrace, textStats } from "../utils/trace.js";
 
 export class OverseerPersona {
 	private gemini: GeminiService;
@@ -60,6 +61,11 @@ Current Personas:
 
 		const initialMessage =
 			"A new vision has been proposed. Please review the repository state and initiate the first micro-task.";
+		logTrace("persona.overseer.newIssuePromptPrepared", {
+			title: textStats(title),
+			body: textStats(body),
+			initialMessage: textStats(initialMessage),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,
@@ -102,6 +108,13 @@ Current Personas:
 		);
 		const initialMessage =
 			"The issue has been updated. Review the full context and decide the next micro-task.";
+		logTrace("persona.overseer.commentPromptPrepared", {
+			commenter,
+			body: textStats(body),
+			initialMessage: textStats(initialMessage),
+			fullContext: textStats(fullContext),
+			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,

--- a/src/personas/planner.ts
+++ b/src/personas/planner.ts
@@ -2,6 +2,7 @@ import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
+import { logTrace, textStats } from "../utils/trace.js";
 
 export class PlannerPersona {
 	private gemini: GeminiService;
@@ -45,6 +46,13 @@ You are authorized to modify files using standard Unix tools via [RUN:command].
 			issueNumber,
 		);
 		const initialMessage = `The Overseer has tasked you with planning a design: ${body}\n\nPlease proceed with breaking this down into micro-tasks in the repository.`;
+		logTrace("persona.planner.promptPrepared", {
+			mentioner,
+			body: textStats(body),
+			initialMessage: textStats(initialMessage),
+			fullContext: textStats(fullContext),
+			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,

--- a/src/personas/product_architect.ts
+++ b/src/personas/product_architect.ts
@@ -2,6 +2,7 @@ import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
+import { logTrace, textStats } from "../utils/trace.js";
 
 export class ProductArchitectPersona {
 	private gemini: GeminiService;
@@ -45,6 +46,13 @@ You are authorized to modify files using [RUN:command] (cat, sed, etc.) or stand
 			issueNumber,
 		);
 		const initialMessage = `The Overseer has tasked you with a micro-task: ${body}\n\nPlease proceed with defining the requirements/design in the repository.`;
+		logTrace("persona.productArchitect.promptPrepared", {
+			mentioner,
+			body: textStats(body),
+			initialMessage: textStats(initialMessage),
+			fullContext: textStats(fullContext),
+			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,

--- a/src/personas/quality.ts
+++ b/src/personas/quality.ts
@@ -2,6 +2,7 @@ import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
+import { logTrace, textStats } from "../utils/trace.js";
 
 export class QualityPersona {
 	private gemini: GeminiService;
@@ -46,6 +47,13 @@ You are authorized to read any file and execute any verification command in the 
 			issueNumber,
 		);
 		const initialMessage = `A quality review has been requested for PR #${prNumber}. Please verify the implementation against project standards using the available tools.`;
+		logTrace("persona.quality.promptPrepared", {
+			developer,
+			prNumber,
+			initialMessage: textStats(initialMessage),
+			fullContext: textStats(fullContext),
+			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
+		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -1,5 +1,6 @@
 import type { GeminiService } from "./gemini.js";
 import { ShellService } from "./shell.js";
+import { logTrace, textStats } from "./trace.js";
 
 export interface IterationResult {
 	finalResponse: string;
@@ -20,6 +21,11 @@ export class AgentRunner {
 		initialMessage: string,
 		maxIterations: number = 50,
 	): Promise<IterationResult> {
+		logTrace("agent.loop.start", {
+			maxIterations,
+			systemInstruction: textStats(systemInstruction),
+			initialMessage: textStats(initialMessage),
+		});
 		const chat = gemini.startChat(systemInstruction);
 		let currentMessage = initialMessage;
 		let iteration = 0;
@@ -28,14 +34,30 @@ export class AgentRunner {
 			iteration++;
 			this.log(`\n=== ITERATION ${iteration} ===\n`);
 			this.log(`AGENT INPUT: ${currentMessage}\n`);
+			logTrace("agent.iteration.begin", {
+				iteration,
+				input: textStats(currentMessage),
+			});
 
+			const sendStartedAt = Date.now();
 			const result = await chat.sendMessage(currentMessage);
 			const responseText = result.response.text();
+			logTrace("agent.iteration.response", {
+				iteration,
+				durationMs: Date.now() - sendStartedAt,
+				response: textStats(responseText),
+				responseIsEmpty: responseText.trim().length === 0,
+			});
 
 			this.log(`AGENT RESPONSE: ${responseText}\n`);
 
 			// Check for shell commands
 			const shellOutput = await this.shell.executeAllBlocks(responseText);
+			logTrace("agent.iteration.shell", {
+				iteration,
+				hadShellOutput: Boolean(shellOutput),
+				shellOutput: textStats(shellOutput),
+			});
 			if (shellOutput) {
 				this.log(`SHELL OUTPUT: ${shellOutput}\n`);
 				currentMessage = `SHELL OUTPUT:\n${shellOutput}\n\nPlease analyze the results and continue your task. If you are finished, provide your final concise summary.`;
@@ -48,6 +70,9 @@ export class AgentRunner {
 			}
 		}
 
+		logTrace("agent.loop.maxIterationsReached", {
+			maxIterations,
+		});
 		return {
 			finalResponse: "ERROR: Max iterations reached without completion.",
 			log: this.sessionLog,

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -4,6 +4,13 @@ import {
 	type GenerativeModel,
 	GoogleGenerativeAI,
 } from "@google/generative-ai";
+import {
+	describeContent,
+	installFetchInstrumentation,
+	logTrace,
+	serializeError,
+	textStats,
+} from "./trace.js";
 
 export interface PersonaResponse {
 	content: string;
@@ -14,11 +21,14 @@ export interface PersonaResponse {
 export class GeminiService {
 	private genAI: GoogleGenerativeAI;
 	private model: GenerativeModel;
+	private readonly modelName: string;
 
 	constructor(apiKey: string) {
+		this.modelName = "gemini-3.1-pro-preview";
+		installFetchInstrumentation();
 		this.genAI = new GoogleGenerativeAI(apiKey);
 		this.model = this.genAI.getGenerativeModel({
-			model: "gemini-3.1-pro-preview",
+			model: this.modelName,
 		});
 	}
 
@@ -40,17 +50,42 @@ export class GeminiService {
 
 		let retries = 0;
 		const maxRetries = 3;
+		logTrace("gemini.promptPersona.prepare", {
+			model: this.modelName,
+			systemInstruction: textStats(systemInstruction),
+			userMessage: textStats(userMessage),
+			context: textStats(context || "No additional context provided."),
+			fullPrompt: textStats(fullPrompt),
+		});
 		while (retries < maxRetries) {
+			const attempt = retries + 1;
+			const startedAt = Date.now();
+			logTrace("gemini.promptPersona.begin", {
+				model: this.modelName,
+				attempt,
+				maxRetries,
+			});
 			try {
 				const result = await this.model.generateContent(fullPrompt);
 				const response = await result.response;
-				return response.text();
+				const responseText = response.text();
+				logTrace("gemini.promptPersona.success", {
+					model: this.modelName,
+					attempt,
+					durationMs: Date.now() - startedAt,
+					responseText: textStats(responseText),
+					usageMetadata: response.usageMetadata,
+					promptFeedback: response.promptFeedback,
+				});
+				return responseText;
 			} catch (error) {
 				retries++;
-				console.error(
-					`Gemini promptPersona failed (attempt ${retries}/${maxRetries}):`,
-					error,
-				);
+				logTrace("gemini.promptPersona.error", {
+					model: this.modelName,
+					attempt,
+					durationMs: Date.now() - startedAt,
+					error: serializeError(error),
+				});
 				if (retries === maxRetries) throw error;
 				await new Promise((resolve) => setTimeout(resolve, 2000 * retries));
 			}
@@ -62,6 +97,11 @@ export class GeminiService {
 	 * Starts a stateful chat session for autonomous iteration.
 	 */
 	startChat(systemInstruction: string, history: Content[] = []): ChatSession {
+		logTrace("gemini.startChat", {
+			model: this.modelName,
+			systemInstruction: textStats(systemInstruction),
+			historyItems: history.length,
+		});
 		const chat = this.model.startChat({
 			history,
 			systemInstruction: {
@@ -75,15 +115,36 @@ export class GeminiService {
 		chat.sendMessage = async (content) => {
 			let retries = 0;
 			const maxRetries = 3;
+			const contentSummary = describeContent(content);
 			while (retries < maxRetries) {
+				const attempt = retries + 1;
+				const startedAt = Date.now();
+				logTrace("gemini.sendMessage.begin", {
+					model: this.modelName,
+					attempt,
+					maxRetries,
+					content: contentSummary,
+				});
 				try {
-					return await originalSendMessage(content);
+					const result = await originalSendMessage(content);
+					const response = await result.response;
+					logTrace("gemini.sendMessage.success", {
+						model: this.modelName,
+						attempt,
+						durationMs: Date.now() - startedAt,
+						candidateCount: response.candidates?.length ?? 0,
+						usageMetadata: response.usageMetadata,
+						promptFeedback: response.promptFeedback,
+					});
+					return result;
 				} catch (error) {
 					retries++;
-					console.error(
-						`Gemini sendMessage failed (attempt ${retries}/${maxRetries}):`,
-						error,
-					);
+					logTrace("gemini.sendMessage.error", {
+						model: this.modelName,
+						attempt,
+						durationMs: Date.now() - startedAt,
+						error: serializeError(error),
+					});
 					if (retries === maxRetries) throw error;
 					await new Promise((resolve) => setTimeout(resolve, 2000 * retries));
 				}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { truncate } from "./text.js";
+import { logTrace, textStats } from "./trace.js";
 
 export class GitHubService {
 	private octokit: Octokit;
@@ -37,11 +38,19 @@ export class GitHubService {
 	}
 
 	async getIssue(owner: string, repo: string, issueNumber: number) {
-		return this.octokit.rest.issues.get({
+		const startedAt = Date.now();
+		const result = await this.octokit.rest.issues.get({
 			owner,
 			repo,
 			issue_number: issueNumber,
 		});
+		logTrace("github.issue.get", {
+			durationMs: Date.now() - startedAt,
+			title: textStats(result.data.title),
+			body: textStats(result.data.body || ""),
+			commentCount: result.data.comments,
+		});
+		return result;
 	}
 
 	async createOrUpdateFile(
@@ -92,12 +101,20 @@ export class GitHubService {
 		repo: string,
 		issueNumber: number,
 	): Promise<string[]> {
+		const startedAt = Date.now();
 		const { data: issue } = await this.octokit.rest.issues.get({
 			owner,
 			repo,
 			issue_number: issueNumber,
 		});
-		return issue.labels.map((l: any) => (typeof l === "string" ? l : l.name));
+		const labels = issue.labels.map((l: any) =>
+			typeof l === "string" ? l : l.name,
+		);
+		logTrace("github.issue.labels", {
+			durationMs: Date.now() - startedAt,
+			labels,
+		});
+		return labels;
 	}
 
 	async setActivePersona(
@@ -183,11 +200,17 @@ export class GitHubService {
 	}
 
 	async listIssueComments(owner: string, repo: string, issueNumber: number) {
-		return this.octokit.rest.issues.listComments({
+		const startedAt = Date.now();
+		const result = await this.octokit.rest.issues.listComments({
 			owner,
 			repo,
 			issue_number: issueNumber,
 		});
+		logTrace("github.issueComments.list", {
+			durationMs: Date.now() - startedAt,
+			commentCount: result.data.length,
+		});
+		return result;
 	}
 
 	async getFullIssueContext(
@@ -211,6 +234,12 @@ export class GitHubService {
 			const commentBody = truncate(comment.body || "", 5000);
 			context += `COMMENT BY @${author}:\n${commentBody}\n\n`;
 		}
+
+		logTrace("github.issueContext.built", {
+			totalComments: comments.data.length,
+			includedComments: recentComments.length,
+			context: textStats(context),
+		});
 
 		return context;
 	}

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,5 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
+import { logTrace, serializeError, textStats } from "./trace.js";
 
 const execAsync = promisify(exec);
 
@@ -13,8 +14,18 @@ export interface ShellResult {
 export class ShellService {
 	async executeCommand(command: string): Promise<ShellResult> {
 		console.log(`Executing shell command: ${command}`);
+		const startedAt = Date.now();
+		logTrace("shell.command.begin", {
+			command,
+		});
 		try {
 			const { stdout, stderr } = await execAsync(command);
+			logTrace("shell.command.success", {
+				command,
+				durationMs: Date.now() - startedAt,
+				stdout: textStats(stdout.trim()),
+				stderr: textStats(stderr.trim()),
+			});
 			return {
 				stdout: stdout.trim(),
 				stderr: stderr.trim(),
@@ -23,6 +34,14 @@ export class ShellService {
 		} catch (error: unknown) {
 			const err = error as { stdout?: string; stderr?: string; code?: number };
 			console.error(`Command execution failed: ${command}`, error);
+			logTrace("shell.command.error", {
+				command,
+				durationMs: Date.now() - startedAt,
+				exitCode: err.code || 1,
+				stdout: textStats(err.stdout?.trim() || ""),
+				stderr: textStats(err.stderr?.trim() || ""),
+				error: serializeError(error),
+			});
 			return {
 				stdout: err.stdout?.trim() || "",
 				stderr: err.stderr?.trim() || "",
@@ -38,9 +57,15 @@ export class ShellService {
 	async executeAllBlocks(content: string): Promise<string> {
 		const runRegex = /\[RUN:([\s\S]+?)\]/g;
 		let fullOutput = "";
+		const matches = Array.from(content.matchAll(runRegex));
+		logTrace("shell.blocks.scan", {
+			content: textStats(content),
+			runMarkerCount: (content.match(/\[RUN:/g) || []).length,
+			parsedBlockCount: matches.length,
+			parsedCommands: matches.map((match) => match[1].trim()),
+		});
 
-		let match = runRegex.exec(content);
-		while (match !== null) {
+		for (const match of matches) {
 			const command = match[1].trim();
 			const result = await this.executeCommand(command);
 
@@ -48,8 +73,6 @@ export class ShellService {
 			if (result.stdout) fullOutput += `STDOUT:\n${result.stdout}\n`;
 			if (result.stderr) fullOutput += `STDERR:\n${result.stderr}\n`;
 			fullOutput += `EXIT CODE: ${result.exitCode}\n`;
-
-			match = runRegex.exec(content);
 		}
 
 		return fullOutput;

--- a/src/utils/trace.ts
+++ b/src/utils/trace.ts
@@ -1,0 +1,243 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
+
+export interface TraceContext {
+	traceId: string;
+	persona: string;
+	owner: string;
+	repo: string;
+	issueNumber: number;
+	runId?: string;
+	eventName?: string;
+	sender?: string;
+	commentUrl?: string;
+	senderPersona?: string;
+}
+
+const traceStorage = new AsyncLocalStorage<TraceContext>();
+
+let fetchInstrumentationInstalled = false;
+let fetchCallSequence = 0;
+
+export function makeTraceId(parts: {
+	runId?: string;
+	persona: string;
+	issueNumber: number;
+}): string {
+	const timestamp = new Date().toISOString().replaceAll(/[:.]/g, "-");
+	return [
+		parts.runId || "local",
+		parts.persona,
+		`issue-${parts.issueNumber}`,
+		timestamp,
+	].join(":");
+}
+
+export function runWithTraceContext<T>(
+	context: TraceContext,
+	fn: () => Promise<T>,
+): Promise<T> {
+	return traceStorage.run(context, fn);
+}
+
+export function getCurrentTraceContext(): TraceContext | undefined {
+	return traceStorage.getStore();
+}
+
+export function textStats(text: string, previewLength: number = 120) {
+	return {
+		chars: text.length,
+		lines: text.length === 0 ? 0 : text.split(/\r?\n/).length,
+		approxTokens: Math.ceil(text.length / 4),
+		sha256_12: createHash("sha256").update(text).digest("hex").slice(0, 12),
+		preview: text.slice(0, previewLength).replaceAll(/\s+/g, " ").trim(),
+	};
+}
+
+export function describeContent(content: unknown) {
+	if (typeof content === "string") {
+		return {
+			type: "string",
+			...textStats(content),
+		};
+	}
+
+	if (Array.isArray(content)) {
+		const json = safeJsonStringify(content);
+		return {
+			type: "array",
+			items: content.length,
+			...textStats(json),
+		};
+	}
+
+	if (content && typeof content === "object") {
+		const json = safeJsonStringify(content);
+		return {
+			type: "object",
+			...textStats(json),
+		};
+	}
+
+	return {
+		type: typeof content,
+		value: content === undefined ? "undefined" : String(content),
+	};
+}
+
+export function serializeError(error: unknown, depth: number = 0): unknown {
+	if (depth > 3) {
+		return "[error depth limit reached]";
+	}
+
+	if (error instanceof Error) {
+		const maybeError = error as Error & {
+			status?: number;
+			statusText?: string;
+			code?: string | number;
+			errno?: string | number;
+			type?: string;
+			cause?: unknown;
+		};
+
+		return {
+			name: error.name,
+			message: error.message,
+			stack: error.stack?.split("\n").slice(0, 8),
+			status: maybeError.status,
+			statusText: maybeError.statusText,
+			code: maybeError.code,
+			errno: maybeError.errno,
+			type: maybeError.type,
+			cause: maybeError.cause
+				? serializeError(maybeError.cause, depth + 1)
+				: undefined,
+		};
+	}
+
+	if (typeof error === "object" && error !== null) {
+		const record = error as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.entries(record).map(([key, value]) => [
+				key,
+				key === "cause" ? serializeError(value, depth + 1) : value,
+			]),
+		);
+	}
+
+	return error;
+}
+
+export function logTrace(
+	event: string,
+	data: Record<string, unknown> = {},
+	context?: Partial<TraceContext>,
+) {
+	const activeContext = getCurrentTraceContext();
+	const payload = {
+		ts: new Date().toISOString(),
+		event,
+		traceId: context?.traceId || activeContext?.traceId,
+		persona: context?.persona || activeContext?.persona,
+		owner: context?.owner || activeContext?.owner,
+		repo: context?.repo || activeContext?.repo,
+		issueNumber: context?.issueNumber || activeContext?.issueNumber,
+		runId: context?.runId || activeContext?.runId,
+		eventName: context?.eventName || activeContext?.eventName,
+		sender: context?.sender || activeContext?.sender,
+		commentUrl: context?.commentUrl || activeContext?.commentUrl,
+		senderPersona: context?.senderPersona || activeContext?.senderPersona,
+		...data,
+	};
+
+	console.log(`[TRACE] ${safeJsonStringify(payload)}`);
+}
+
+export function installFetchInstrumentation() {
+	if (fetchInstrumentationInstalled || typeof globalThis.fetch !== "function") {
+		return;
+	}
+
+	fetchInstrumentationInstalled = true;
+	const originalFetch = globalThis.fetch.bind(globalThis);
+
+	globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = resolveUrl(input);
+		const method = init?.method || inferMethod(input) || "GET";
+		const fetchCallId = ++fetchCallSequence;
+		const startedAt = Date.now();
+		const isGeminiRequest = url.includes("generativelanguage.googleapis.com");
+
+		if (isGeminiRequest) {
+			logTrace("fetch.begin", {
+				fetchCallId,
+				url,
+				method,
+				hasAbortSignal: Boolean(init?.signal),
+				signalAborted: init?.signal?.aborted || false,
+			});
+		}
+
+		try {
+			const response = await originalFetch(input, init);
+			if (isGeminiRequest) {
+				logTrace("fetch.response", {
+					fetchCallId,
+					url,
+					method,
+					durationMs: Date.now() - startedAt,
+					status: response.status,
+					statusText: response.statusText,
+					ok: response.ok,
+					retryAfter: response.headers.get("retry-after"),
+					contentType: response.headers.get("content-type"),
+					contentLength: response.headers.get("content-length"),
+					xRequestId:
+						response.headers.get("x-request-id") ||
+						response.headers.get("x-guploader-uploadid"),
+				});
+			}
+			return response;
+		} catch (error) {
+			if (isGeminiRequest) {
+				logTrace("fetch.error", {
+					fetchCallId,
+					url,
+					method,
+					durationMs: Date.now() - startedAt,
+					error: serializeError(error),
+				});
+			}
+			throw error;
+		}
+	}) as typeof fetch;
+}
+
+function resolveUrl(input: RequestInfo | URL): string {
+	if (typeof input === "string") {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	return input.url;
+}
+
+function inferMethod(input: RequestInfo | URL): string | undefined {
+	if (
+		typeof input === "object" &&
+		!(input instanceof URL) &&
+		"method" in input
+	) {
+		return input.method;
+	}
+	return undefined;
+}
+
+function safeJsonStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return JSON.stringify(String(value));
+	}
+}


### PR DESCRIPTION
## What changed
This adds targeted instrumentation across the Gemini persona execution path so we can compare `overseer` and `product-architect` runs with the same level of detail.

## Why it changed
The current workflow logs do not explain the repeated `product-architect` failures or the recurring ~5 minute delay before Gemini errors surface. This PR adds enough tracing to determine whether the difference is in prompt construction, GitHub context assembly, Gemini request timing, retry behavior, empty responses, or shell parsing.

## User impact
Future workflow runs will emit structured `[TRACE]` log lines with per-persona trace IDs, prompt/context size stats, Gemini fetch begin/end/error timing, retry attempt durations, empty-response detection, and shell block parsing details.

## Root cause under investigation
We need to distinguish true model/API hangs from request construction differences between personas, especially between `overseer` and `product-architect`.

## Validation
- `npm run build`
- `npm test`