### PR TITLE
[codex] Fix CI formatting for Gemini trace instrumentation

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -282,15 +282,15 @@ async function run() {
 					}
 					return null;
 				});
-				} catch (error) {
-					console.error(`Persona failed: ${executedPersona}`, error);
-					await runWithTraceContext(traceContext, async () => {
-						logTrace("dispatcher.persona.error", {
-							error:
-								error instanceof Error ? error.stack || error.message : error,
-						});
+			} catch (error) {
+				console.error(`Persona failed: ${executedPersona}`, error);
+				await runWithTraceContext(traceContext, async () => {
+					logTrace("dispatcher.persona.error", {
+						error:
+							error instanceof Error ? error.stack || error.message : error,
 					});
-					iterationResult = {
+				});
+				iterationResult = {
 					finalResponse: `ERROR: Execution failed. Details: ${error instanceof Error ? error.message : String(error)}`,
 					log: `CRITICAL ERROR: ${error}`,
 				};


### PR DESCRIPTION
## What changed
This fixes the formatting regression in `src/dispatch.ts` introduced by the Gemini trace instrumentation merge.

## Why it changed
The previous PR was merged with a red `validate` check. CI was failing on a Biome formatting error in `src/dispatch.ts`.

## Validation
- `npx biome check src/`
- `npx tsc --noEmit`
- `npm test`