### PR TITLE
Adopt structured agent actions and Gemini streaming

### DIFF
--- a/src/personas/developer_tester.ts
+++ b/src/personas/developer_tester.ts
@@ -1,3 +1,4 @@
+import { AGENT_PROTOCOL_PROMPT } from "../utils/agent_protocol.js";
 import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
@@ -13,14 +14,15 @@ export class DeveloperTesterPersona {
 You are the Developer/Tester, an expert Linux developer operating in a Nix-based execution environment on GitHub Actions. Your job is to implement code and functional tests.
 
 AUTONOMOUS RULES:
-1. **Plan-Act-Verify:** Always use [RUN:command] to explore the codebase, apply changes, and then run verification commands (lint, test, build).
+1. **Plan-Act-Verify:** Use structured JSON actions to explore the codebase, apply changes, and then run verification commands (lint, test, build).
 2. **Persistence:** Use standard git commands to commit and push your changes to your working branch.
 3. **Repo-Centric Communication:** Large amounts of technical detail should be in code comments or documentation files.
 4. **Conciseness:** Your final response must be a maximum 3-sentence summary of the changes you implemented and the verification results.
 5. **Handoff:** You do not delegate. Provide your summary and the Dispatcher will return control to the Overseer.
 
-You are authorized to modify any file in the repository using standard Unix tools via [RUN:command].
-    `;
+You are authorized to modify any file in the repository using shell commands emitted through the JSON action protocol.
+${AGENT_PROTOCOL_PROMPT}
+	`;
 
 	constructor(gemini: GeminiService, github: GitHubService) {
 		this.gemini = gemini;

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -1,3 +1,4 @@
+import { AGENT_PROTOCOL_PROMPT } from "../utils/agent_protocol.js";
 import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
@@ -16,7 +17,7 @@ You are the Overseer, an expert Linux developer operating in a Nix-based executi
 ORCHESTRATION RULES:
 1. **Strict Boundary:** You are forbidden from writing implementation code or documentation directly to the repository. You act as a reviewer and orchestrator only.
 2. **Micro-Tasking:** Never give an agent a multi-step checklist. Task them with EXACTLY ONE bite-sized sub-task at a time.
-3. **Internal Iteration:** You can execute shell commands [RUN:command] to inspect the repository, verify file existence, or check project state before making a decision.
+3. **Internal Iteration:** You can execute shell commands through the JSON action protocol to inspect the repository, verify file existence, or check project state before making a decision.
 4. **Conciseness:** Your final response must be a maximum 3-sentence summary of your assessment, followed by the mandatory delegation suffix.
 
 DELEGATION SUFFIX:
@@ -28,7 +29,8 @@ Current Personas:
 - @planner: Task decomposition (Authorized to write files/plans).
 - @developer-tester: Code implementation and testing (Authorized to write files).
 - @quality: Verification and review (Reviewer only, NO file writing).
-    `;
+${AGENT_PROTOCOL_PROMPT}
+	`;
 
 	constructor(gemini: GeminiService, github: GitHubService) {
 		this.gemini = gemini;

--- a/src/personas/planner.ts
+++ b/src/personas/planner.ts
@@ -1,3 +1,4 @@
+import { AGENT_PROTOCOL_PROMPT } from "../utils/agent_protocol.js";
 import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
@@ -13,13 +14,14 @@ export class PlannerPersona {
 You are the Planner, an expert Linux developer operating in a Nix-based execution environment on GitHub Actions. Your job is to break down designs into actionable micro-tasks.
 
 AUTONOMOUS RULES:
-1. **Internal Iteration:** Use [RUN:command] to explore the repository and verify the feasibility of your plan.
+1. **Internal Iteration:** Use structured JSON actions to explore the repository and verify the feasibility of your plan.
 2. **Repo-Centric Communication:** Write detailed plans, checklists, or task breakdowns directly to files in the repository (e.g., in docs/plans/).
 3. **Conciseness:** Your final response must be a maximum 3-sentence summary of the planning work you completed and the files you created.
 4. **Handoff:** You do not delegate. Provide your summary and the Dispatcher will return control to the Overseer.
 
-You are authorized to modify files using standard Unix tools via [RUN:command].
-    `;
+You are authorized to modify files using shell commands emitted through the JSON action protocol.
+${AGENT_PROTOCOL_PROMPT}
+	`;
 
 	constructor(gemini: GeminiService, github: GitHubService) {
 		this.gemini = gemini;

--- a/src/personas/product_architect.ts
+++ b/src/personas/product_architect.ts
@@ -1,3 +1,4 @@
+import { AGENT_PROTOCOL_PROMPT } from "../utils/agent_protocol.js";
 import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
@@ -13,13 +14,14 @@ export class ProductArchitectPersona {
 You are the Product/Architect, an expert Linux developer operating in a Nix-based execution environment on GitHub Actions. Your job is to define requirements and high-level technical designs.
 
 AUTONOMOUS RULES:
-1. **Internal Iteration:** Use [RUN:command] to explore the codebase and verify your design before finalizing.
+1. **Internal Iteration:** Use structured JSON actions to explore the codebase and verify your design before finalizing.
 2. **Repo-Centric Communication:** Write detailed requirements and architectural documents directly to files in the repository (e.g., in docs/architecture/).
 3. **Conciseness:** Your final response must be a maximum 3-sentence summary of the files you created or updated. DO NOT include the full content of the documents in your final comment.
 4. **Handoff:** You do not delegate. Simply provide your summary and the Dispatcher will return control to the Overseer.
 
-You are authorized to modify files using [RUN:command] (cat, sed, etc.) or standard Unix tools.
-    `;
+You are authorized to modify files using shell commands emitted through the JSON action protocol.
+${AGENT_PROTOCOL_PROMPT}
+	`;
 
 	constructor(gemini: GeminiService, github: GitHubService) {
 		this.gemini = gemini;

--- a/src/personas/quality.ts
+++ b/src/personas/quality.ts
@@ -1,3 +1,4 @@
+import { AGENT_PROTOCOL_PROMPT } from "../utils/agent_protocol.js";
 import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
@@ -14,13 +15,14 @@ You are the Quality agent, an expert Linux developer operating in a Nix-based ex
 
 AUTONOMOUS RULES:
 1. **Strict Boundary:** You are forbidden from writing implementation code or documentation directly to the repository. You act as a reviewer only.
-2. **Internal Iteration:** Use [RUN:command] to execute test suites, check linting, verify builds, and inspect code.
+2. **Internal Iteration:** Use structured JSON actions to execute test suites, check linting, verify builds, and inspect code.
 3. **Repo-Centric Reporting:** If you identify major issues, you may describe them in your concise summary, but do not fix them yourself.
 4. **Conciseness:** Your final response must be a maximum 3-sentence summary of your quality assessment and verification results.
 5. **Handoff:** You do not delegate. Provide your summary and the Dispatcher will return control to the Overseer.
 
 You are authorized to read any file and execute any verification command in the VM.
-    `;
+${AGENT_PROTOCOL_PROMPT}
+	`;
 
 	constructor(gemini: GeminiService, github: GitHubService) {
 		this.gemini = gemini;

--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+	AGENT_PROTOCOL_VERSION,
+	parseAgentProtocolResponse,
+} from "./agent_protocol.js";
+
+describe("parseAgentProtocolResponse", () => {
+	it("parses a plain JSON response", () => {
+		const parsed = parseAgentProtocolResponse(
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				next_step: "Inspect the repository root.",
+				actions: [{ type: "run_shell", command: "ls -la" }],
+				task_status: "in_progress",
+			}),
+		);
+
+		expect(parsed.protocol.task_status).toBe("in_progress");
+		expect(parsed.protocol.actions).toEqual([
+			{ type: "run_shell", command: "ls -la" },
+		]);
+	});
+
+	it("parses fenced JSON responses", () => {
+		const parsed = parseAgentProtocolResponse(`\`\`\`json
+{
+  "version": "${AGENT_PROTOCOL_VERSION}",
+  "next_step": "Finish up.",
+  "actions": [],
+  "task_status": "done",
+  "final_response": "Completed successfully."
+}
+\`\`\``);
+
+		expect(parsed.protocol.task_status).toBe("done");
+		expect(parsed.protocol.final_response).toBe("Completed successfully.");
+	});
+
+	it("extracts an embedded JSON object", () => {
+		const parsed = parseAgentProtocolResponse(`
+I will comply.
+{
+  "version": "${AGENT_PROTOCOL_VERSION}",
+  "next_step": "Review shell output.",
+  "actions": [{"type": "run_shell", "command": "cat package.json"}],
+  "task_status": "in_progress"
+}`);
+
+		expect(parsed.protocol.actions[0]?.command).toBe("cat package.json");
+	});
+
+	it("rejects done responses without final_response", () => {
+		expect(() =>
+			parseAgentProtocolResponse(
+				JSON.stringify({
+					version: AGENT_PROTOCOL_VERSION,
+					next_step: "Stop.",
+					actions: [],
+					task_status: "done",
+				}),
+			),
+		).toThrow(/final_response/);
+	});
+});

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -1,0 +1,261 @@
+export const AGENT_PROTOCOL_VERSION = "overseer/v1";
+
+export type AgentTaskStatus = "in_progress" | "done";
+
+export interface RunShellAction {
+	type: "run_shell";
+	command: string;
+}
+
+export type AgentAction = RunShellAction;
+
+export interface AgentProtocolResponse {
+	version: typeof AGENT_PROTOCOL_VERSION;
+	next_step: string;
+	actions: AgentAction[];
+	task_status: AgentTaskStatus;
+	final_response?: string;
+	plan?: string[];
+}
+
+export interface ParsedAgentProtocolResponse {
+	protocol: AgentProtocolResponse;
+	rawJson: string;
+}
+
+export const AGENT_PROTOCOL_PROMPT = `
+RESPONSE PROTOCOL:
+- Return exactly one JSON object and nothing else.
+- Use \`"version": "${AGENT_PROTOCOL_VERSION}"\`.
+- Always include \`next_step\`, \`actions\`, and \`task_status\`.
+- If you need to inspect or modify the repository, respond with \`"task_status": "in_progress"\` and exactly one action: \`{"type":"run_shell","command":"..."}\`.
+- If the task is complete, respond with \`"task_status": "done"\`, \`"actions": []\`, and \`final_response\` containing the concise human-facing summary that should be posted back to GitHub.
+- Do not use \`[RUN:command]\`, markdown fences, or prose outside the JSON object.
+`;
+
+export function buildProtocolRepairMessage(
+	error: string,
+	previousResponse: string,
+): string {
+	return [
+		`Your previous response was invalid: ${error}`,
+		`Return exactly one JSON object matching protocol "${AGENT_PROTOCOL_VERSION}".`,
+		"Do not use markdown fences or any prose outside the JSON object.",
+		"Previous response:",
+		previousResponse,
+	].join("\n\n");
+}
+
+export function buildContinuationMessage(shellOutput: string): string {
+	return [
+		"SHELL OUTPUT:",
+		shellOutput,
+		"",
+		`Continue the task using protocol "${AGENT_PROTOCOL_VERSION}".`,
+		"Return exactly one JSON object.",
+	].join("\n");
+}
+
+export function parseAgentProtocolResponse(
+	responseText: string,
+): ParsedAgentProtocolResponse {
+	const rawJson = extractJsonObject(responseText);
+	let parsed: unknown;
+
+	try {
+		parsed = JSON.parse(rawJson);
+	} catch (error) {
+		throw new Error(
+			`response was not valid JSON: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("top-level JSON value must be an object");
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const version = requireNonEmptyString(record.version, "version");
+	if (version !== AGENT_PROTOCOL_VERSION) {
+		throw new Error(
+			`version must be "${AGENT_PROTOCOL_VERSION}", received "${version}"`,
+		);
+	}
+
+	const nextStep = requireNonEmptyString(record.next_step, "next_step");
+	const taskStatus = parseTaskStatus(record.task_status);
+	const actions = parseActions(record.actions);
+	const finalResponse = parseOptionalNonEmptyString(
+		record.final_response,
+		"final_response",
+	);
+	const plan = parseOptionalPlan(record.plan);
+
+	if (taskStatus === "in_progress" && actions.length !== 1) {
+		throw new Error(
+			'task_status "in_progress" requires exactly one action in actions[]',
+		);
+	}
+
+	if (taskStatus === "done") {
+		if (actions.length !== 0) {
+			throw new Error('task_status "done" requires actions to be empty');
+		}
+		if (!finalResponse) {
+			throw new Error(
+				'task_status "done" requires a non-empty final_response string',
+			);
+		}
+	}
+
+	return {
+		rawJson,
+		protocol: {
+			version: AGENT_PROTOCOL_VERSION,
+			next_step: nextStep,
+			actions,
+			task_status: taskStatus,
+			final_response: finalResponse,
+			plan,
+		},
+	};
+}
+
+function extractJsonObject(responseText: string): string {
+	const trimmed = responseText.trim();
+	if (!trimmed) {
+		throw new Error("response was empty");
+	}
+
+	const fencedMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+	if (fencedMatch?.[1]) {
+		return fencedMatch[1].trim();
+	}
+
+	if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+		return trimmed;
+	}
+
+	const embeddedObject = extractBalancedObject(trimmed);
+	if (embeddedObject) {
+		return embeddedObject;
+	}
+
+	throw new Error("could not find a JSON object in the response");
+}
+
+function extractBalancedObject(text: string): string | null {
+	let startIndex = -1;
+	let depth = 0;
+	let inString = false;
+	let isEscaped = false;
+
+	for (let index = 0; index < text.length; index++) {
+		const char = text[index];
+		if (!char) {
+			continue;
+		}
+
+		if (isEscaped) {
+			isEscaped = false;
+			continue;
+		}
+
+		if (char === "\\") {
+			isEscaped = true;
+			continue;
+		}
+
+		if (char === '"') {
+			inString = !inString;
+			continue;
+		}
+
+		if (inString) {
+			continue;
+		}
+
+		if (char === "{") {
+			if (depth === 0) {
+				startIndex = index;
+			}
+			depth++;
+			continue;
+		}
+
+		if (char === "}") {
+			if (depth === 0) {
+				continue;
+			}
+			depth--;
+			if (depth === 0 && startIndex >= 0) {
+				return text.slice(startIndex, index + 1);
+			}
+		}
+	}
+
+	return null;
+}
+
+function requireNonEmptyString(value: unknown, fieldName: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new Error(`${fieldName} must be a non-empty string`);
+	}
+	return value.trim();
+}
+
+function parseOptionalNonEmptyString(
+	value: unknown,
+	fieldName: string,
+): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	return requireNonEmptyString(value, fieldName);
+}
+
+function parseTaskStatus(value: unknown): AgentTaskStatus {
+	if (value === "in_progress" || value === "done") {
+		return value;
+	}
+	throw new Error('task_status must be either "in_progress" or "done"');
+}
+
+function parseActions(value: unknown): AgentAction[] {
+	if (!Array.isArray(value)) {
+		throw new Error("actions must be an array");
+	}
+
+	return value.map((action, index) => parseAction(action, index));
+}
+
+function parseAction(value: unknown, index: number): AgentAction {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`actions[${index}] must be an object`);
+	}
+
+	const record = value as Record<string, unknown>;
+	if (record.type !== "run_shell") {
+		throw new Error(`actions[${index}].type must be "run_shell"`);
+	}
+
+	return {
+		type: "run_shell",
+		command: requireNonEmptyString(record.command, `actions[${index}].command`),
+	};
+}
+
+function parseOptionalPlan(value: unknown): string[] | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (!Array.isArray(value)) {
+		throw new Error("plan must be an array of strings when provided");
+	}
+
+	return value.map((entry, index) =>
+		requireNonEmptyString(entry, `plan[${index}]`),
+	);
+}

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_PROTOCOL_VERSION } from "./agent_protocol.js";
+import { AgentRunner } from "./agent_runner.js";
+
+describe("AgentRunner", () => {
+	it("executes structured shell actions and returns the final response", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				next_step: "Inspect the repository root.",
+				actions: [{ type: "run_shell", command: "printf 'hello'" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				next_step: "Return control to the dispatcher.",
+				actions: [],
+				task_status: "done",
+				final_response: "Verified the repository root and completed the task.",
+			}),
+		];
+
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage() {
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner();
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			5,
+		);
+
+		expect(result.finalResponse).toBe(
+			"Verified the repository root and completed the task.",
+		);
+		expect(result.log).toContain("hello");
+		expect(result.log).toContain("PROTOCOL RESPONSE");
+	});
+});

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -1,3 +1,9 @@
+import {
+	buildContinuationMessage,
+	buildProtocolRepairMessage,
+	type ParsedAgentProtocolResponse,
+	parseAgentProtocolResponse,
+} from "./agent_protocol.js";
 import type { GeminiService } from "./gemini.js";
 import { ShellService } from "./shell.js";
 import { logTrace, textStats } from "./trace.js";
@@ -41,7 +47,7 @@ export class AgentRunner {
 
 			const sendStartedAt = Date.now();
 			const result = await chat.sendMessage(currentMessage);
-			const responseText = result.response.text();
+			const responseText = result.text;
 			logTrace("agent.iteration.response", {
 				iteration,
 				durationMs: Date.now() - sendStartedAt,
@@ -51,23 +57,47 @@ export class AgentRunner {
 
 			this.log(`AGENT RESPONSE: ${responseText}\n`);
 
-			// Check for shell commands
-			const shellOutput = await this.shell.executeAllBlocks(responseText);
+			let parsedResponse: ParsedAgentProtocolResponse;
+			try {
+				parsedResponse = parseAgentProtocolResponse(responseText);
+			} catch (error) {
+				logTrace("agent.iteration.protocolError", {
+					iteration,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				currentMessage = buildProtocolRepairMessage(
+					error instanceof Error ? error.message : String(error),
+					responseText,
+				);
+				continue;
+			}
+
+			logTrace("agent.iteration.protocol", {
+				iteration,
+				taskStatus: parsedResponse.protocol.task_status,
+				nextStep: parsedResponse.protocol.next_step,
+				actionCount: parsedResponse.protocol.actions.length,
+				finalResponse: textStats(parsedResponse.protocol.final_response || ""),
+			});
+			this.log(`PROTOCOL RESPONSE: ${parsedResponse.rawJson}\n`);
+
+			if (parsedResponse.protocol.task_status === "done") {
+				return {
+					finalResponse: parsedResponse.protocol.final_response || "",
+					log: this.sessionLog,
+				};
+			}
+
+			const shellOutput = await this.shell.executeActions(
+				parsedResponse.protocol.actions,
+			);
 			logTrace("agent.iteration.shell", {
 				iteration,
 				hadShellOutput: Boolean(shellOutput),
 				shellOutput: textStats(shellOutput),
 			});
-			if (shellOutput) {
-				this.log(`SHELL OUTPUT: ${shellOutput}\n`);
-				currentMessage = `SHELL OUTPUT:\n${shellOutput}\n\nPlease analyze the results and continue your task. If you are finished, provide your final concise summary.`;
-			} else {
-				// No more commands, assume the agent is finished
-				return {
-					finalResponse: responseText,
-					log: this.sessionLog,
-				};
-			}
+			this.log(`SHELL OUTPUT: ${shellOutput}\n`);
+			currentMessage = buildContinuationMessage(shellOutput);
 		}
 
 		logTrace("agent.loop.maxIterationsReached", {

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -1,9 +1,13 @@
-import type { Content } from "@google/generative-ai";
+import type {
+	Content,
+	EnhancedGenerateContentResponse,
+	Part,
+} from "@google/generative-ai";
 import {
-	type ChatSession,
 	type GenerativeModel,
 	GoogleGenerativeAI,
 } from "@google/generative-ai";
+import { AGENT_PROTOCOL_VERSION } from "./agent_protocol.js";
 import {
 	describeContent,
 	installFetchInstrumentation,
@@ -15,16 +19,31 @@ import {
 export interface PersonaResponse {
 	content: string;
 	action?: string;
-	metadata?: Record<string, any>;
+	metadata?: Record<string, unknown>;
+}
+
+export interface GeminiChatResult {
+	text: string;
+	response: EnhancedGenerateContentResponse;
+}
+
+export interface GeminiChatSession {
+	sendMessage(
+		content: string | Array<string | Part>,
+	): Promise<GeminiChatResult>;
 }
 
 export class GeminiService {
 	private genAI: GoogleGenerativeAI;
 	private model: GenerativeModel;
 	private readonly modelName: string;
+	private readonly requestTimeoutMs: number;
 
 	constructor(apiKey: string) {
 		this.modelName = "gemini-3.1-pro-preview";
+		this.requestTimeoutMs = Number(
+			process.env.GEMINI_REQUEST_TIMEOUT_MS || "120000",
+		);
 		installFetchInstrumentation();
 		this.genAI = new GoogleGenerativeAI(apiKey);
 		this.model = this.genAI.getGenerativeModel({
@@ -56,6 +75,7 @@ export class GeminiService {
 			userMessage: textStats(userMessage),
 			context: textStats(context || "No additional context provided."),
 			fullPrompt: textStats(fullPrompt),
+			requestTimeoutMs: this.requestTimeoutMs,
 		});
 		while (retries < maxRetries) {
 			const attempt = retries + 1;
@@ -64,9 +84,12 @@ export class GeminiService {
 				model: this.modelName,
 				attempt,
 				maxRetries,
+				requestTimeoutMs: this.requestTimeoutMs,
 			});
 			try {
-				const result = await this.model.generateContent(fullPrompt);
+				const result = await this.model.generateContent(fullPrompt, {
+					timeout: this.requestTimeoutMs,
+				});
 				const response = await result.response;
 				const responseText = response.text();
 				logTrace("gemini.promptPersona.success", {
@@ -90,17 +113,20 @@ export class GeminiService {
 				await new Promise((resolve) => setTimeout(resolve, 2000 * retries));
 			}
 		}
-		return ""; // Should not be reached
+		return "";
 	}
 
-	/**
-	 * Starts a stateful chat session for autonomous iteration.
-	 */
-	startChat(systemInstruction: string, history: Content[] = []): ChatSession {
+	startChat(
+		systemInstruction: string,
+		history: Content[] = [],
+	): GeminiChatSession {
 		logTrace("gemini.startChat", {
 			model: this.modelName,
 			systemInstruction: textStats(systemInstruction),
 			historyItems: history.length,
+			requestTimeoutMs: this.requestTimeoutMs,
+			responseMimeType: "application/json",
+			responseProtocolVersion: AGENT_PROTOCOL_VERSION,
 		});
 		const chat = this.model.startChat({
 			history,
@@ -108,50 +134,89 @@ export class GeminiService {
 				role: "system",
 				parts: [{ text: systemInstruction }],
 			},
+			generationConfig: {
+				responseMimeType: "application/json",
+			},
 		});
+		const originalSendMessageStream = chat.sendMessageStream.bind(chat);
 
-		// Wrap sendMessage with retry logic
-		const originalSendMessage = chat.sendMessage.bind(chat);
-		chat.sendMessage = async (content) => {
-			let retries = 0;
-			const maxRetries = 3;
-			const contentSummary = describeContent(content);
-			while (retries < maxRetries) {
-				const attempt = retries + 1;
-				const startedAt = Date.now();
-				logTrace("gemini.sendMessage.begin", {
-					model: this.modelName,
-					attempt,
-					maxRetries,
-					content: contentSummary,
-				});
-				try {
-					const result = await originalSendMessage(content);
-					const response = await result.response;
-					logTrace("gemini.sendMessage.success", {
+		return {
+			sendMessage: async (content) => {
+				let retries = 0;
+				const maxRetries = 3;
+				const contentSummary = describeContent(content);
+
+				while (retries < maxRetries) {
+					const attempt = retries + 1;
+					const startedAt = Date.now();
+					logTrace("gemini.sendMessage.begin", {
 						model: this.modelName,
 						attempt,
-						durationMs: Date.now() - startedAt,
-						candidateCount: response.candidates?.length ?? 0,
-						usageMetadata: response.usageMetadata,
-						promptFeedback: response.promptFeedback,
+						maxRetries,
+						content: contentSummary,
+						requestTimeoutMs: this.requestTimeoutMs,
+						streaming: true,
 					});
-					return result;
-				} catch (error) {
-					retries++;
-					logTrace("gemini.sendMessage.error", {
-						model: this.modelName,
-						attempt,
-						durationMs: Date.now() - startedAt,
-						error: serializeError(error),
-					});
-					if (retries === maxRetries) throw error;
-					await new Promise((resolve) => setTimeout(resolve, 2000 * retries));
+
+					try {
+						const result = await originalSendMessageStream(content, {
+							timeout: this.requestTimeoutMs,
+						});
+						let chunkCount = 0;
+						let streamedText = "";
+						let firstChunkDelayMs: number | undefined;
+
+						for await (const chunk of result.stream) {
+							const chunkText = chunk.text();
+							chunkCount++;
+							streamedText += chunkText;
+							if (firstChunkDelayMs === undefined) {
+								firstChunkDelayMs = Date.now() - startedAt;
+							}
+							logTrace("gemini.sendMessage.chunk", {
+								model: this.modelName,
+								attempt,
+								chunkIndex: chunkCount,
+								chunkText: textStats(chunkText),
+								accumulatedText: textStats(streamedText),
+								firstChunkDelayMs,
+							});
+						}
+
+						const response = await result.response;
+						const responseText = response.text();
+						logTrace("gemini.sendMessage.success", {
+							model: this.modelName,
+							attempt,
+							durationMs: Date.now() - startedAt,
+							chunkCount,
+							firstChunkDelayMs,
+							responseText: textStats(responseText),
+							streamedText: textStats(streamedText),
+							candidateCount: response.candidates?.length ?? 0,
+							usageMetadata: response.usageMetadata,
+							promptFeedback: response.promptFeedback,
+						});
+
+						return {
+							text: responseText,
+							response,
+						};
+					} catch (error) {
+						retries++;
+						logTrace("gemini.sendMessage.error", {
+							model: this.modelName,
+							attempt,
+							durationMs: Date.now() - startedAt,
+							error: serializeError(error),
+						});
+						if (retries === maxRetries) throw error;
+						await new Promise((resolve) => setTimeout(resolve, 2000 * retries));
+					}
 				}
-			}
-			throw new Error("Gemini sendMessage failed after max retries");
-		};
 
-		return chat;
+				throw new Error("Gemini sendMessage failed after max retries");
+			},
+		};
 	}
 }

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,5 +1,6 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
+import type { AgentAction } from "./agent_protocol.js";
 import { logTrace, serializeError, textStats } from "./trace.js";
 
 const execAsync = promisify(exec);
@@ -51,25 +52,24 @@ export class ShellService {
 		}
 	}
 
-	/**
-	 * Parses a string for [RUN:command]...[/RUN] blocks and executes them.
-	 */
-	async executeAllBlocks(content: string): Promise<string> {
-		const runRegex = /\[RUN:([\s\S]+?)\]/g;
+	async executeActions(actions: AgentAction[]): Promise<string> {
 		let fullOutput = "";
-		const matches = Array.from(content.matchAll(runRegex));
-		logTrace("shell.blocks.scan", {
-			content: textStats(content),
-			runMarkerCount: (content.match(/\[RUN:/g) || []).length,
-			parsedBlockCount: matches.length,
-			parsedCommands: matches.map((match) => match[1].trim()),
+		logTrace("shell.actions.scan", {
+			actionCount: actions.length,
+			actions: actions.map((action) => ({
+				type: action.type,
+				command: textStats(action.command),
+			})),
 		});
 
-		for (const match of matches) {
-			const command = match[1].trim();
-			const result = await this.executeCommand(command);
+		for (const action of actions) {
+			if (action.type !== "run_shell") {
+				continue;
+			}
 
-			fullOutput += `\n--- EXECUTING: ${command} ---\n`;
+			const result = await this.executeCommand(action.command);
+
+			fullOutput += `\n--- EXECUTING: ${action.command} ---\n`;
 			if (result.stdout) fullOutput += `STDOUT:\n${result.stdout}\n`;
 			if (result.stderr) fullOutput += `STDERR:\n${result.stderr}\n`;
 			fullOutput += `EXIT CODE: ${result.exitCode}\n`;


### PR DESCRIPTION
## Summary
- replace the ad-hoc `[RUN:command]` loop contract with a validated `overseer/v1` JSON protocol
- update all personas and the agent runner/shell executor to use structured `run_shell` actions
- switch Gemini autonomous chat turns to streaming with chunk tracing and an explicit request timeout

## Verification
- npm run lint
- npm run build
- npm test

## Notes
- `npm run lint` still reports the existing warnings in `src/index.ts` and `src/utils/github.ts`; this PR does not add new lint warnings.
- Streaming improves observability once headers arrive, and the new timeout prevents the old 5-minute wait from persisting indefinitely.