### PR TITLE
[codex] Guard persistence loop and narrow persona handoffs

### DIFF
--- a/.github/scripts/persistence_backstop.sh
+++ b/.github/scripts/persistence_backstop.sh
@@ -148,6 +148,8 @@ cat >"$artifact_root/metadata.json" <<EOF
 EOF
 
 cat >"$comment_path" <<EOF
+<!-- overseer:persistence-backstop -->
+
 The workflow persistence backstop detected repo changes that were not verified on \`${target_branch}\`.
 
 - Run: ${run_url}

--- a/.github/workflows/overseer.yml
+++ b/.github/workflows/overseer.yml
@@ -21,28 +21,53 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Backstop Sentinel
+        id: backstop_guard
+        run: |
+          skip_workflow=false
+          if [ "${GITHUB_EVENT_NAME}" = "issue_comment" ]; then
+            comment_body="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+            if printf '%s' "$comment_body" | grep -Fq '<!-- overseer:persistence-backstop -->'; then
+              skip_workflow=true
+              echo "Skipping workflow because it was triggered by a persistence backstop comment."
+            fi
+          fi
+          echo "skip_workflow=${skip_workflow}" >> "$GITHUB_OUTPUT"
+
       - name: Record Initial Git State
         id: git_state
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         run: echo "initial_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Install Nix
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Magic Nix Cache
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         uses: DeterminateSystems/magic-nix-cache-action@v7
 
       - name: Setup Node.js
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
+      - name: Configure Git Identity
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
+        run: |
+          git config --global user.name "Overseer Bot"
+          git config --global user.email "overseer-bot@users.noreply.github.com"
+
       - name: Install Dependencies
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         run: npm install
 
       - name: Run Overseer Dispatcher
         id: dispatcher
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OVERSEER_TOKEN || secrets.GITHUB_TOKEN }}
@@ -50,7 +75,7 @@ jobs:
 
       - name: Persistence Backstop
         id: persistence_backstop
-        if: always()
+        if: always() && steps.backstop_guard.outputs.skip_workflow != 'true'
         env:
           INITIAL_SHA: ${{ steps.git_state.outputs.initial_sha }}
         run: bash .github/scripts/persistence_backstop.sh
@@ -72,7 +97,7 @@ jobs:
             --body-file "${{ steps.persistence_backstop.outputs.comment_path }}"
 
       - name: Upload Session Logs
-        if: always()
+        if: always() && steps.backstop_guard.outputs.skip_workflow != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: agent-session-logs-${{ github.run_id }}

--- a/src/personas/developer_tester.ts
+++ b/src/personas/developer_tester.ts
@@ -8,11 +8,11 @@ import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
 import type { PersistenceService } from "../utils/persistence.js";
+import { extractDirectedTask } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class DeveloperTesterPersona {
 	private gemini: GeminiService;
-	private github: GitHubService;
 	private persistence: PersistenceService;
 	private runner: AgentRunner;
 
@@ -33,18 +33,17 @@ ${AGENT_PROTOCOL_PROMPT}
 
 	constructor(
 		gemini: GeminiService,
-		github: GitHubService,
+		_github: GitHubService,
 		persistence: PersistenceService,
 	) {
 		this.gemini = gemini;
-		this.github = github;
 		this.persistence = persistence;
 		this.runner = new AgentRunnerClass();
 	}
 
 	async handleTask(
-		owner: string,
-		repo: string,
+		_owner: string,
+		_repo: string,
 		issueNumber: number,
 		taskDescription: string,
 		_commentUrl?: string,
@@ -54,21 +53,16 @@ ${AGENT_PROTOCOL_PROMPT}
 			`Developer/Tester handling task for issue #${issueNumber}: ${taskDescription}`,
 		);
 
-		const fullContext = await this.github.getFullIssueContext(
-			owner,
-			repo,
-			issueNumber,
-		);
-		const initialMessage = `The Overseer has tasked you with implementation: ${taskDescription}
+		const directedTask = extractDirectedTask(taskDescription);
+		const initialMessage = `The Overseer has tasked you with implementation: ${directedTask}
 
 Target persistence branch: bot/issue-${issueNumber}
 
 Please proceed with the Plan-Act-Verify cycle in the repository. Use persist_work when the changes are ready, and do not finish until you verify the remote issue branch contains your intended result.`;
 		logTrace("persona.developerTester.promptPrepared", {
 			taskDescription: textStats(taskDescription),
+			directedTask: textStats(directedTask),
 			initialMessage: textStats(initialMessage),
-			fullContext: textStats(fullContext),
-			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
 		});
 
 		const runnerOptions: AgentRunnerOptions = {
@@ -79,7 +73,7 @@ Please proceed with the Plan-Act-Verify cycle in the repository. Use persist_wor
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			DeveloperTesterPersona.SYSTEM_INSTRUCTION,
-			`${initialMessage}\n\nCONTEXT:\n${fullContext}`,
+			initialMessage,
 			50,
 			runnerOptions,
 		);

--- a/src/personas/planner.ts
+++ b/src/personas/planner.ts
@@ -8,11 +8,11 @@ import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
 import type { PersistenceService } from "../utils/persistence.js";
+import { extractDirectedTask } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class PlannerPersona {
 	private gemini: GeminiService;
-	private github: GitHubService;
 	private persistence: PersistenceService;
 	private runner: AgentRunner;
 
@@ -33,18 +33,17 @@ ${AGENT_PROTOCOL_PROMPT}
 
 	constructor(
 		gemini: GeminiService,
-		github: GitHubService,
+		_github: GitHubService,
 		persistence: PersistenceService,
 	) {
 		this.gemini = gemini;
-		this.github = github;
 		this.persistence = persistence;
 		this.runner = new AgentRunnerClass();
 	}
 
 	async handleMention(
-		owner: string,
-		repo: string,
+		_owner: string,
+		_repo: string,
 		issueNumber: number,
 		mentioner: string,
 		body: string,
@@ -55,12 +54,8 @@ ${AGENT_PROTOCOL_PROMPT}
 			`Planner handling mention from ${mentioner} in issue #${issueNumber}`,
 		);
 
-		const fullContext = await this.github.getFullIssueContext(
-			owner,
-			repo,
-			issueNumber,
-		);
-		const initialMessage = `The Overseer has tasked you with planning a design: ${body}
+		const directedTask = extractDirectedTask(body);
+		const initialMessage = `The Overseer has tasked you with planning a design: ${directedTask}
 
 Target persistence branch: bot/issue-${issueNumber}
 
@@ -68,9 +63,8 @@ Please proceed with breaking this down into micro-tasks in the repository. Use p
 		logTrace("persona.planner.promptPrepared", {
 			mentioner,
 			body: textStats(body),
+			directedTask: textStats(directedTask),
 			initialMessage: textStats(initialMessage),
-			fullContext: textStats(fullContext),
-			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
 		});
 
 		const runnerOptions: AgentRunnerOptions = {
@@ -80,7 +74,7 @@ Please proceed with breaking this down into micro-tasks in the repository. Use p
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			PlannerPersona.SYSTEM_INSTRUCTION,
-			`${initialMessage}\n\nCONTEXT:\n${fullContext}`,
+			initialMessage,
 			50,
 			runnerOptions,
 		);

--- a/src/personas/product_architect.ts
+++ b/src/personas/product_architect.ts
@@ -8,11 +8,11 @@ import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
 import type { PersistenceService } from "../utils/persistence.js";
+import { extractDirectedTask } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class ProductArchitectPersona {
 	private gemini: GeminiService;
-	private github: GitHubService;
 	private persistence: PersistenceService;
 	private runner: AgentRunner;
 
@@ -33,18 +33,17 @@ ${AGENT_PROTOCOL_PROMPT}
 
 	constructor(
 		gemini: GeminiService,
-		github: GitHubService,
+		_github: GitHubService,
 		persistence: PersistenceService,
 	) {
 		this.gemini = gemini;
-		this.github = github;
 		this.persistence = persistence;
 		this.runner = new AgentRunnerClass();
 	}
 
 	async handleMention(
-		owner: string,
-		repo: string,
+		_owner: string,
+		_repo: string,
 		issueNumber: number,
 		mentioner: string,
 		body: string,
@@ -55,12 +54,8 @@ ${AGENT_PROTOCOL_PROMPT}
 			`Product/Architect handling mention from ${mentioner} in issue #${issueNumber}`,
 		);
 
-		const fullContext = await this.github.getFullIssueContext(
-			owner,
-			repo,
-			issueNumber,
-		);
-		const initialMessage = `The Overseer has tasked you with a micro-task: ${body}
+		const directedTask = extractDirectedTask(body);
+		const initialMessage = `The Overseer has tasked you with a micro-task: ${directedTask}
 
 Target persistence branch: bot/issue-${issueNumber}
 
@@ -68,9 +63,8 @@ Please proceed with defining the requirements/design in the repository. Use pers
 		logTrace("persona.productArchitect.promptPrepared", {
 			mentioner,
 			body: textStats(body),
+			directedTask: textStats(directedTask),
 			initialMessage: textStats(initialMessage),
-			fullContext: textStats(fullContext),
-			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
 		});
 
 		const runnerOptions: AgentRunnerOptions = {
@@ -81,7 +75,7 @@ Please proceed with defining the requirements/design in the repository. Use pers
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			ProductArchitectPersona.SYSTEM_INSTRUCTION,
-			`${initialMessage}\n\nCONTEXT:\n${fullContext}`,
+			initialMessage,
 			50,
 			runnerOptions,
 		);

--- a/src/personas/quality.ts
+++ b/src/personas/quality.ts
@@ -3,11 +3,11 @@ import type { AgentRunner, IterationResult } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
+import { extractDirectedTask } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class QualityPersona {
 	private gemini: GeminiService;
-	private github: GitHubService;
 	private runner: AgentRunner;
 
 	static readonly SYSTEM_INSTRUCTION = `
@@ -25,15 +25,14 @@ You are authorized to read any file and execute any verification command in the 
 ${AGENT_PROTOCOL_PROMPT}
 	`;
 
-	constructor(gemini: GeminiService, github: GitHubService) {
+	constructor(gemini: GeminiService, _github: GitHubService) {
 		this.gemini = gemini;
-		this.github = github;
 		this.runner = new AgentRunnerClass();
 	}
 
 	async handleReviewRequest(
-		owner: string,
-		repo: string,
+		_owner: string,
+		_repo: string,
 		issueNumber: number,
 		prNumber: number,
 		developer: string,
@@ -44,24 +43,21 @@ ${AGENT_PROTOCOL_PROMPT}
 			`Quality agent handling review request from ${developer} for PR #${prNumber} on issue #${issueNumber}`,
 		);
 
-		const fullContext = await this.github.getFullIssueContext(
-			owner,
-			repo,
-			issueNumber,
+		const directedTask = extractDirectedTask(
+			`A quality review has been requested for PR #${prNumber}. Please verify the implementation against project standards using the available tools.`,
 		);
-		const initialMessage = `A quality review has been requested for PR #${prNumber}. Please verify the implementation against project standards using the available tools.`;
+		const initialMessage = directedTask;
 		logTrace("persona.quality.promptPrepared", {
 			developer,
 			prNumber,
+			directedTask: textStats(directedTask),
 			initialMessage: textStats(initialMessage),
-			fullContext: textStats(fullContext),
-			combinedInput: textStats(`${initialMessage}\n\nCONTEXT:\n${fullContext}`),
 		});
 
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			QualityPersona.SYSTEM_INSTRUCTION,
-			`${initialMessage}\n\nCONTEXT:\n${fullContext}`,
+			initialMessage,
 		);
 	}
 }

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parsePorcelainPaths } from "./persistence.js";
+
+describe("parsePorcelainPaths", () => {
+	it("parses added, modified, and untracked entries without status prefixes", () => {
+		const output =
+			" A flake.lock\0 M package-lock.json\0?? docs/architecture/V2_ARCHITECTURE_DESIGN.md\0";
+
+		expect(parsePorcelainPaths(output)).toEqual([
+			"flake.lock",
+			"package-lock.json",
+			"docs/architecture/V2_ARCHITECTURE_DESIGN.md",
+		]);
+	});
+
+	it("uses the destination path for renames", () => {
+		const output =
+			"R  docs/old-name.md\0docs/new-name.md\0?? docs/plans/plan.md\0";
+
+		expect(parsePorcelainPaths(output)).toEqual([
+			"docs/new-name.md",
+			"docs/plans/plan.md",
+		]);
+	});
+});

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -25,11 +25,55 @@ export interface PersistWorkResult {
 	details?: Record<string, string | string[] | number | boolean>;
 }
 
+export function parsePorcelainPaths(statusOutput: string): string[] {
+	const entries = statusOutput.split("\0").filter(Boolean);
+	const paths: string[] = [];
+
+	for (let index = 0; index < entries.length; index++) {
+		const entry = entries[index];
+		if (!entry || entry.length < 4) {
+			continue;
+		}
+
+		const status = entry.slice(0, 2);
+		const path = entry.slice(3);
+		if (!path) {
+			continue;
+		}
+
+		if (status.includes("R") || status.includes("C")) {
+			const renamedPath = entries[index + 1];
+			if (renamedPath) {
+				paths.push(renamedPath);
+				index++;
+				continue;
+			}
+		}
+
+		paths.push(path);
+	}
+
+	return Array.from(new Set(paths));
+}
+
 export class PersistenceService {
 	async ensureIssueBranch(
 		issueNumber: number,
 	): Promise<EnsureIssueBranchResult> {
 		const branchName = this.getBranchName(issueNumber);
+		await this.runGit(
+			["config", "--global", "user.name", "Overseer Bot"],
+			"persistence.gitConfigUserName",
+		);
+		await this.runGit(
+			[
+				"config",
+				"--global",
+				"user.email",
+				"overseer-bot@users.noreply.github.com",
+			],
+			"persistence.gitConfigUserEmail",
+		);
 		await this.runGit(["fetch", "origin"], "persistence.fetchOrigin");
 
 		const remoteExists = await this.remoteBranchExists(branchName);
@@ -249,21 +293,10 @@ export class PersistenceService {
 
 	private async getRelevantChangedPaths(): Promise<string[]> {
 		const statusResult = await this.runGit(
-			["status", "--porcelain=1", "--untracked-files=all"],
+			["status", "--porcelain=1", "-z", "--untracked-files=all"],
 			"persistence.status",
 		);
-		const rawPaths = statusResult.stdout
-			.split("\n")
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.map((line) => line.replace(/^[A-Z? ]{2}\s+/, ""))
-			.map((line) => {
-				if (line.includes(" -> ")) {
-					const [, targetPath] = line.split(" -> ");
-					return targetPath || line;
-				}
-				return line;
-			});
+		const rawPaths = parsePorcelainPaths(statusResult.stdout);
 
 		return Array.from(
 			new Set(rawPaths.filter((path) => !this.isIgnoredPath(path))),

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -19,6 +19,19 @@ export function getAttribution(
 	return `I am the **${personaName}**, and I am responding to ${source} from ${target}.\n\n`;
 }
 
+export function extractDirectedTask(body: string): string {
+	let task = body.trim();
+
+	task = task.replace(
+		/^I am the \*\*Overseer\*\*, and I am responding to [\s\S]*?\.\n\n/,
+		"",
+	);
+	task = task.replace(/\n*\s*Next step: @[a-z-]+ to take action\.?\s*$/i, "");
+	task = task.replace(/\n*\s*Next step: human review required\.?\s*$/i, "");
+
+	return task.trim();
+}
+
 export async function isLimitReached(
 	github: GitHubService,
 	owner: string,


### PR DESCRIPTION
## What changed
- add a persistence-backstop sentinel comment marker and skip the workflow when an `issue_comment` run is triggered by that marker
- configure git identity before dispatcher work begins and again in the persistence branch setup path
- parse `git status --porcelain -z` output correctly so `persist_work` stages real paths instead of fake names like `A flake.lock`
- stop feeding planner, product/architect, developer/tester, and quality the full issue-thread context; they now receive the Overseer handoff comment distilled to the directed task
- add unit coverage for porcelain path parsing

## Why
Recent runs showed two mechanical persistence failures and one loop trigger:
- the backstop could comment on its own recovery comment and retrigger itself
- `persist_work` could fail staging because porcelain status lines were parsed incorrectly
- `persist_work` could fail committing because git identity was not configured
- downstream personas were wasting turns exploring because they were given the full issue context rather than the specific Overseer instruction

## Impact
- backstop comments should no longer recursively wake the workflow
- persistence should stage and commit reliably on the issue branch
- specialist personas should start from a narrower task prompt and spend fewer iterations on irrelevant thread history

## Validation
- `npm run lint`
- `npm run build`
- `npm test`

`npm run lint` still reports the existing warnings in `src/index.ts` and `src/utils/github.ts`; this PR does not add new warnings.