### PR TITLE
[codex] Use staged index for persistence paths

### DIFF
--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -1,25 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { parsePorcelainPaths } from "./persistence.js";
+import { parseNullDelimitedPaths } from "./persistence.js";
 
-describe("parsePorcelainPaths", () => {
-	it("parses added, modified, and untracked entries without status prefixes", () => {
+describe("parseNullDelimitedPaths", () => {
+	it("preserves complete filenames from null-delimited git output", () => {
 		const output =
-			" A flake.lock\0 M package-lock.json\0?? docs/architecture/V2_ARCHITECTURE_DESIGN.md\0";
+			"flake.lock\0package-lock.json\0docs/architecture/V2_ARCHITECTURE_DESIGN.md\0";
 
-		expect(parsePorcelainPaths(output)).toEqual([
+		expect(parseNullDelimitedPaths(output)).toEqual([
 			"flake.lock",
 			"package-lock.json",
 			"docs/architecture/V2_ARCHITECTURE_DESIGN.md",
 		]);
 	});
 
-	it("uses the destination path for renames", () => {
-		const output =
-			"R  docs/old-name.md\0docs/new-name.md\0?? docs/plans/plan.md\0";
+	it("drops empty records and de-duplicates paths", () => {
+		const output = "\0docs/plans/plan.md\0docs/plans/plan.md\0\0";
 
-		expect(parsePorcelainPaths(output)).toEqual([
-			"docs/new-name.md",
-			"docs/plans/plan.md",
-		]);
+		expect(parseNullDelimitedPaths(output)).toEqual(["docs/plans/plan.md"]);
 	});
 });

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -25,35 +25,8 @@ export interface PersistWorkResult {
 	details?: Record<string, string | string[] | number | boolean>;
 }
 
-export function parsePorcelainPaths(statusOutput: string): string[] {
-	const entries = statusOutput.split("\0").filter(Boolean);
-	const paths: string[] = [];
-
-	for (let index = 0; index < entries.length; index++) {
-		const entry = entries[index];
-		if (!entry || entry.length < 4) {
-			continue;
-		}
-
-		const status = entry.slice(0, 2);
-		const path = entry.slice(3);
-		if (!path) {
-			continue;
-		}
-
-		if (status.includes("R") || status.includes("C")) {
-			const renamedPath = entries[index + 1];
-			if (renamedPath) {
-				paths.push(renamedPath);
-				index++;
-				continue;
-			}
-		}
-
-		paths.push(path);
-	}
-
-	return Array.from(new Set(paths));
+export function parseNullDelimitedPaths(output: string): string[] {
+	return Array.from(new Set(output.split("\0").filter(Boolean)));
 }
 
 export class PersistenceService {
@@ -145,7 +118,19 @@ export class PersistenceService {
 		}
 
 		const aheadCount = await this.getAheadCount(branch);
-		const changedFiles = await this.getRelevantChangedPaths();
+
+		try {
+			await this.stageRelevantChanges(branch);
+		} catch (error) {
+			return this.makeErrorResult(
+				branch,
+				"stage_failed",
+				"Failed to stage repository changes for persistence.",
+				error,
+			);
+		}
+
+		const changedFiles = await this.getStagedChangedPaths();
 		if (changedFiles.length === 0 && aheadCount === 0) {
 			return {
 				ok: false,
@@ -190,21 +175,6 @@ export class PersistenceService {
 				changed_files: pushedFiles,
 				message: `Pushed ${aheadCount} existing local commit(s) to ${branch}.`,
 			};
-		}
-
-		try {
-			await this.runGit(["add", "--", ...changedFiles], "persistence.stage", {
-				branch,
-				changedFiles,
-			});
-		} catch (error) {
-			return this.makeErrorResult(
-				branch,
-				"stage_failed",
-				"Failed to stage repository changes for persistence.",
-				error,
-				{ changed_files: changedFiles },
-			);
 		}
 
 		const commitMessage = `${persona}: issue #${issueNumber} persist work`;
@@ -291,15 +261,28 @@ export class PersistenceService {
 		return `bot/issue-${issueNumber}`;
 	}
 
-	private async getRelevantChangedPaths(): Promise<string[]> {
-		const statusResult = await this.runGit(
-			["status", "--porcelain=1", "-z", "--untracked-files=all"],
-			"persistence.status",
+	private async stageRelevantChanges(branch: string): Promise<void> {
+		await this.runGit(
+			[
+				"add",
+				"-A",
+				"--",
+				".",
+				":(glob,exclude).backstop/**",
+				":(glob,exclude)session_*.log",
+			],
+			"persistence.stage",
+			{ branch },
 		);
-		const rawPaths = parsePorcelainPaths(statusResult.stdout);
+	}
 
-		return Array.from(
-			new Set(rawPaths.filter((path) => !this.isIgnoredPath(path))),
+	private async getStagedChangedPaths(): Promise<string[]> {
+		const result = await this.runGit(
+			["diff", "--cached", "--name-only", "-z"],
+			"persistence.stagedChangedPaths",
+		);
+		return parseNullDelimitedPaths(result.stdout).filter(
+			(path) => !this.isIgnoredPath(path),
 		);
 	}
 
@@ -339,15 +322,13 @@ export class PersistenceService {
 		branchName: string,
 	): Promise<string[]> {
 		const result = await this.runGit(
-			["diff", "--name-only", `origin/${branchName}..HEAD`],
+			["diff", "--name-only", "-z", `origin/${branchName}..HEAD`],
 			"persistence.changedFilesAgainstRemote",
 			{ branchName },
 		);
-		return result.stdout
-			.split("\n")
-			.map((line) => line.trim())
-			.filter(Boolean)
-			.filter((path) => !this.isIgnoredPath(path));
+		return parseNullDelimitedPaths(result.stdout).filter(
+			(path) => !this.isIgnoredPath(path),
+		);
 	}
 
 	private classifyPushFailure(stderr: string): string {


### PR DESCRIPTION
## What changed
- remove the `git status --porcelain` path parser from persistence
- stage relevant repo changes directly with `git add -A` plus explicit exclusions for backstop artifacts and session logs
- derive `changed_files` from the staged index via `git diff --cached --name-only -z`
- use the same null-delimited parsing for remote-vs-head file reporting
- replace the old porcelain parser tests with regression coverage for null-delimited path parsing, including the `flake.lock` filename case

## Why
The previous implementation parsed human-oriented status output and had an off-by-one bug that could truncate filenames, producing bad paths like `lake.lock`. That made persistence fail at the staging step.

This PR switches to the more reliable automation path:
- let Git decide what to stage
- inspect the staged index rather than re-parsing status text
- only parse null-delimited filename lists produced by machine-oriented Git commands

## Impact
- persistence no longer depends on brittle status parsing
- filenames like `flake.lock` are preserved exactly
- deletes, renames, and untracked files are handled by Git’s own staging logic instead of custom parsing

## Validation
- `npm run lint`
- `npm run build`
- `npm test`

`npm run lint` still reports the existing warnings in `src/index.ts` and `src/utils/github.ts`; this PR does not add new warnings.