### PR TITLE
[codex] Gate issue-open dispatch and skip no-op backstops

### DIFF
--- a/.github/workflows/overseer.yml
+++ b/.github/workflows/overseer.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Persistence Backstop
         id: persistence_backstop
-        if: always() && steps.backstop_guard.outputs.skip_workflow != 'true'
+        if: always() && steps.backstop_guard.outputs.skip_workflow != 'true' && steps.dispatcher.outputs.persona_executed == 'true'
         env:
           INITIAL_SHA: ${{ steps.git_state.outputs.initial_sha }}
         run: bash .github/scripts/persistence_backstop.sh

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -8,7 +8,10 @@ import type { IterationResult } from "./utils/agent_runner.js";
 import { GeminiService } from "./utils/gemini.js";
 import { GitHubService } from "./utils/github.js";
 import { PersistenceService } from "./utils/persistence.js";
-import { getAttribution } from "./utils/persona_helper.js";
+import {
+	getAttribution,
+	hasExplicitPersonaMention,
+} from "./utils/persona_helper.js";
 import { truncate } from "./utils/text.js";
 import {
 	logTrace,
@@ -17,6 +20,14 @@ import {
 	type TraceContext,
 	textStats,
 } from "./utils/trace.js";
+
+function appendGithubOutput(key: string, value: string): void {
+	const outputPath = process.env.GITHUB_OUTPUT;
+	if (!outputPath) {
+		return;
+	}
+	fs.appendFileSync(outputPath, `${key}=${value}\n`);
+}
 
 async function run() {
 	const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -50,6 +61,8 @@ async function run() {
 		hasGeminiApiKey: geminiApiKey.length > 0,
 		hasGithubToken: githubToken.length > 0,
 	});
+	appendGithubOutput("persona_executed", "false");
+	appendGithubOutput("executed_persona", "");
 
 	console.log(`Received GitHub event: ${eventName} from ${sender}`);
 
@@ -68,6 +81,20 @@ async function run() {
 	} else {
 		console.log(`Ignoring event type: ${eventName}`);
 		return;
+	}
+
+	if (eventName === "issues" && eventData.action === "opened") {
+		const issueText = `${eventData.issue.title || ""}\n${eventData.issue.body || ""}`;
+		if (!hasExplicitPersonaMention(issueText, "@overseer")) {
+			logTrace("dispatcher.issueOpen.skippedWithoutMention", {
+				title: textStats(eventData.issue.title || ""),
+				body: textStats(eventData.issue.body || ""),
+			});
+			console.log(
+				"Skipping issue-open dispatch because the issue does not explicitly mention @overseer",
+			);
+			return;
+		}
 	}
 
 	const branchState = await persistence.ensureIssueBranch(issueNumber);
@@ -110,6 +137,8 @@ async function run() {
 
 	if (eventName === "issues" && eventData.action === "opened") {
 		executedPersona = "overseer";
+		appendGithubOutput("persona_executed", "true");
+		appendGithubOutput("executed_persona", executedPersona);
 		traceContext = {
 			traceId: makeTraceId({
 				runId: process.env.GITHUB_RUN_ID,
@@ -190,6 +219,8 @@ async function run() {
 		}
 
 		if (shouldExecute && executedPersona) {
+			appendGithubOutput("persona_executed", "true");
+			appendGithubOutput("executed_persona", executedPersona);
 			traceContext = {
 				traceId: makeTraceId({
 					runId: process.env.GITHUB_RUN_ID,

--- a/src/utils/persona_helper.test.ts
+++ b/src/utils/persona_helper.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { hasExplicitPersonaMention } from "./persona_helper.js";
+
+describe("hasExplicitPersonaMention", () => {
+	it("detects an explicit overseer mention in issue text", () => {
+		expect(
+			hasExplicitPersonaMention(
+				"@overseer please review this issue",
+				"@overseer",
+			),
+		).toBe(true);
+	});
+
+	it("does not trigger when the issue text is blank", () => {
+		expect(hasExplicitPersonaMention("", "@overseer")).toBe(false);
+	});
+
+	it("does not trigger on other persona handles", () => {
+		expect(
+			hasExplicitPersonaMention(
+				"@product-architect please review this issue",
+				"@overseer",
+			),
+		).toBe(false);
+	});
+});

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -32,6 +32,14 @@ export function extractDirectedTask(body: string): string {
 	return task.trim();
 }
 
+export function hasExplicitPersonaMention(
+	text: string,
+	personaHandle: string,
+): boolean {
+	const escapedHandle = personaHandle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	return new RegExp(`(^|\\s)${escapedHandle}(?=\\s|$)`, "i").test(text);
+}
+
 export async function isLimitReached(
 	github: GitHubService,
 	owner: string,


### PR DESCRIPTION
## What changed
- gate the `issues.opened` dispatcher path so Overseer only runs when the issue title/body explicitly mentions `@overseer`
- write `persona_executed` and `executed_persona` step outputs from the dispatcher
- run the workflow persistence backstop only when the dispatcher actually executed a persona
- add regression tests for explicit persona mention detection

## Why
Issue `#44` showed two distinct workflow problems:
- a blank issue still triggered the `issues.opened` Overseer path, which raced with the real human comment and produced an unrelated handoff
- later no-op workflow runs still executed the persistence backstop and posted noisy recovery comments even though no persona work had happened

This PR fixes both behaviors directly.

## Impact
- opening a blank issue no longer wakes Overseer by default
- issue-open dispatch now requires an explicit `@overseer` mention in the creation text
- no-op runs that execute no persona will not post persistence backstop comments

## Validation
- `npm run lint`
- `npm run build`
- `npm test`

`npm run lint` still reports the existing warnings in `src/index.ts` and `src/utils/github.ts`; this PR does not add new warnings.