### PR TITLE
[codex] Prepare issue branch before workflow setup

### DIFF
--- a/.github/workflows/overseer.yml
+++ b/.github/workflows/overseer.yml
@@ -34,6 +34,29 @@ jobs:
           fi
           echo "skip_workflow=${skip_workflow}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare Issue Branch
+        id: issue_branch
+        if: steps.backstop_guard.outputs.skip_workflow != 'true'
+        run: |
+          prepared=false
+          issue_number="$(jq -r '.issue.number // empty' "$GITHUB_EVENT_PATH")"
+          if [ -n "$issue_number" ]; then
+            target_branch="bot/issue-${issue_number}"
+            git fetch origin "$target_branch" || true
+            if git show-ref --verify --quiet "refs/remotes/origin/${target_branch}"; then
+              git checkout -B "$target_branch" "origin/$target_branch"
+              echo "created=false" >> "$GITHUB_OUTPUT"
+            else
+              git checkout -B "$target_branch" "origin/main"
+              git push -u origin "$target_branch"
+              echo "created=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "issue_number=${issue_number}" >> "$GITHUB_OUTPUT"
+            echo "target_branch=${target_branch}" >> "$GITHUB_OUTPUT"
+            prepared=true
+          fi
+          echo "prepared=${prepared}" >> "$GITHUB_OUTPUT"
+
       - name: Record Initial Git State
         id: git_state
         if: steps.backstop_guard.outputs.skip_workflow != 'true'

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -49,7 +49,27 @@ export class PersistenceService {
 		);
 		await this.runGit(["fetch", "origin"], "persistence.fetchOrigin");
 
+		const currentBranch = (
+			await this.runGit(
+				["rev-parse", "--abbrev-ref", "HEAD"],
+				"persistence.currentBranch",
+			)
+		).stdout.trim();
 		const remoteExists = await this.remoteBranchExists(branchName);
+		if (currentBranch === branchName) {
+			if (!remoteExists) {
+				await this.runGit(
+					["push", "-u", "origin", branchName],
+					"persistence.pushCurrentBranch",
+					{ branchName },
+				);
+			}
+			return {
+				branchName,
+				created: !remoteExists,
+			};
+		}
+
 		if (remoteExists) {
 			await this.runGit(
 				["checkout", "-B", branchName, `origin/${branchName}`],


### PR DESCRIPTION
## What changed
- add a workflow step that resolves and checks out `bot/issue-<n>` immediately after the sentinel guard and before any Nix or Node setup runs
- create and push the issue branch from `origin/main` in the workflow if it does not already exist
- update `PersistenceService.ensureIssueBranch()` to treat an already-checked-out issue branch as a no-op instead of forcing another checkout

## Why
Run `23862194445` failed before any persona work started because the workflow dirtied `flake.lock` and `package-lock.json` on `main`, then the dispatcher tried to switch to `origin/bot/issue-46` and Git aborted:
- `flake.lock` would be overwritten by checkout
- `package-lock.json` would be overwritten by checkout

The root cause was branch selection happening too late. Setup steps were mutating the wrong branch before the dispatcher got to `ensureIssueBranch()`.

## Impact
- setup now runs on the issue branch instead of on `main`
- the dispatcher no longer re-checks out the same branch after setup and re-triggers the same failure
- issue runs should stop failing on branch checkout due to setup-generated lockfile churn

## Validation
- `npm run lint`
- `npm run build`
- `npm test`
- `bash -n .github/scripts/persistence_backstop.sh`

`npm run lint` still reports the existing warnings in `src/index.ts` and `src/utils/github.ts`; this PR does not add new warnings.