### PR TITLE
[codex] Add raw LLM turn tracing

### DIFF
--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -36,7 +36,9 @@ export class AgentRunner {
 		logTrace("agent.loop.start", {
 			maxIterations,
 			systemInstruction: textStats(systemInstruction),
+			systemInstructionRaw: systemInstruction,
 			initialMessage: textStats(initialMessage),
+			initialMessageRaw: initialMessage,
 		});
 		const chat = gemini.startChat(systemInstruction);
 		let currentMessage = initialMessage;
@@ -49,6 +51,7 @@ export class AgentRunner {
 			logTrace("agent.iteration.begin", {
 				iteration,
 				input: textStats(currentMessage),
+				inputRaw: currentMessage,
 			});
 
 			const sendStartedAt = Date.now();
@@ -58,6 +61,7 @@ export class AgentRunner {
 				iteration,
 				durationMs: Date.now() - sendStartedAt,
 				response: textStats(responseText),
+				responseRaw: responseText,
 				responseIsEmpty: responseText.trim().length === 0,
 			});
 
@@ -84,6 +88,7 @@ export class AgentRunner {
 				nextStep: parsedResponse.protocol.next_step,
 				actionCount: parsedResponse.protocol.actions.length,
 				finalResponse: textStats(parsedResponse.protocol.final_response || ""),
+				finalResponseRaw: parsedResponse.protocol.final_response || "",
 			});
 			this.log(`PROTOCOL RESPONSE: ${parsedResponse.rawJson}\n`);
 

--- a/src/utils/gemini.ts
+++ b/src/utils/gemini.ts
@@ -33,6 +33,16 @@ export interface GeminiChatSession {
 	): Promise<GeminiChatResult>;
 }
 
+function serializeContentForTrace(
+	content: string | Array<string | Part>,
+): string {
+	if (typeof content === "string") {
+		return content;
+	}
+
+	return JSON.stringify(content, null, 2);
+}
+
 export class GeminiService {
 	private genAI: GoogleGenerativeAI;
 	private model: GenerativeModel;
@@ -72,9 +82,13 @@ export class GeminiService {
 		logTrace("gemini.promptPersona.prepare", {
 			model: this.modelName,
 			systemInstruction: textStats(systemInstruction),
+			systemInstructionRaw: systemInstruction,
 			userMessage: textStats(userMessage),
+			userMessageRaw: userMessage,
 			context: textStats(context || "No additional context provided."),
+			contextRaw: context || "No additional context provided.",
 			fullPrompt: textStats(fullPrompt),
+			fullPromptRaw: fullPrompt,
 			requestTimeoutMs: this.requestTimeoutMs,
 		});
 		while (retries < maxRetries) {
@@ -97,6 +111,7 @@ export class GeminiService {
 					attempt,
 					durationMs: Date.now() - startedAt,
 					responseText: textStats(responseText),
+					responseTextRaw: responseText,
 					usageMetadata: response.usageMetadata,
 					promptFeedback: response.promptFeedback,
 				});
@@ -123,7 +138,9 @@ export class GeminiService {
 		logTrace("gemini.startChat", {
 			model: this.modelName,
 			systemInstruction: textStats(systemInstruction),
+			systemInstructionRaw: systemInstruction,
 			historyItems: history.length,
+			historyRaw: history,
 			requestTimeoutMs: this.requestTimeoutMs,
 			responseMimeType: "application/json",
 			responseProtocolVersion: AGENT_PROTOCOL_VERSION,
@@ -145,6 +162,7 @@ export class GeminiService {
 				let retries = 0;
 				const maxRetries = 3;
 				const contentSummary = describeContent(content);
+				const contentRaw = serializeContentForTrace(content);
 
 				while (retries < maxRetries) {
 					const attempt = retries + 1;
@@ -154,6 +172,7 @@ export class GeminiService {
 						attempt,
 						maxRetries,
 						content: contentSummary,
+						contentRaw,
 						requestTimeoutMs: this.requestTimeoutMs,
 						streaming: true,
 					});
@@ -192,7 +211,9 @@ export class GeminiService {
 							chunkCount,
 							firstChunkDelayMs,
 							responseText: textStats(responseText),
+							responseTextRaw: responseText,
 							streamedText: textStats(streamedText),
+							streamedTextRaw: streamedText,
 							candidateCount: response.candidates?.length ?? 0,
 							usageMetadata: response.usageMetadata,
 							promptFeedback: response.promptFeedback,


### PR DESCRIPTION
## What changed

- log the raw system instruction and initial message at agent loop start
- log the raw per-turn input and raw model response for every agent iteration
- log the raw chat start payload and raw sendMessage content at the Gemini boundary
- log the raw Gemini response text alongside the existing summary/token trace fields

## Why

We need to see exactly what the runtime is sending to and receiving from Gemini on every turn. Recent Overseer runs showed the merged prompt changes were present on `main`, but the model still returned non-compliant handoffs. This PR makes that visible directly in the workflow logs.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`

`lint` still reports the same pre-existing warnings in `src/index.ts` and `src/utils/github.ts`. This PR does not add new lint warnings.