### PR TITLE
[codex] Persist trace logs as JSONL artifacts

### DIFF
--- a/.github/workflows/overseer.yml
+++ b/.github/workflows/overseer.yml
@@ -94,6 +94,7 @@ jobs:
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.OVERSEER_TOKEN || secrets.GITHUB_TOKEN }}
+          TRACE_JSONL_PATH: trace_${{ github.run_id }}.jsonl
         run: nix develop --command npx tsx src/dispatch.ts
 
       - name: Persistence Backstop
@@ -126,3 +127,12 @@ jobs:
           name: agent-session-logs-${{ github.run_id }}
           path: session_*.log
           retention-days: 7
+
+      - name: Upload Trace JSONL
+        if: always() && steps.backstop_guard.outputs.skip_workflow != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: trace-jsonl-${{ github.run_id }}
+          path: trace_*.jsonl
+          retention-days: 7
+          if-no-files-found: warn

--- a/src/utils/trace.ts
+++ b/src/utils/trace.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 
 export interface TraceContext {
 	traceId: string;
@@ -18,6 +20,23 @@ const traceStorage = new AsyncLocalStorage<TraceContext>();
 
 let fetchInstrumentationInstalled = false;
 let fetchCallSequence = 0;
+let traceJsonlPathInitialized = false;
+
+function getTraceJsonlPath(): string {
+	return (
+		process.env.TRACE_JSONL_PATH ||
+		`trace_${process.env.GITHUB_RUN_ID || "local"}.jsonl`
+	);
+}
+
+function ensureTraceJsonlParentDir() {
+	if (traceJsonlPathInitialized) {
+		return;
+	}
+
+	traceJsonlPathInitialized = true;
+	mkdirSync(dirname(getTraceJsonlPath()), { recursive: true });
+}
 
 export function makeTraceId(parts: {
 	runId?: string;
@@ -150,7 +169,17 @@ export function logTrace(
 		...data,
 	};
 
-	console.log(`[TRACE] ${safeJsonStringify(payload)}`);
+	const serializedPayload = safeJsonStringify(payload);
+	console.log(`[TRACE] ${serializedPayload}`);
+
+	try {
+		ensureTraceJsonlParentDir();
+		appendFileSync(getTraceJsonlPath(), `${serializedPayload}\n`, "utf8");
+	} catch (error) {
+		console.error(
+			`[TRACE_WRITE_ERROR] ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 }
 
 export function installFetchInstrumentation() {


### PR DESCRIPTION
## What changed

- write every `logTrace(...)` payload to a local `.jsonl` file in addition to the console log
- set a deterministic trace file path in the dispatcher workflow using `TRACE_JSONL_PATH=trace_${{ github.run_id }}.jsonl`
- upload the trace file at the end of the workflow as `trace-jsonl-${{ github.run_id }}`

## Why

The GitHub Actions console output is truncating long trace lines, which makes the new detailed tracing hard to inspect. Persisting the full trace stream to a `.jsonl` artifact gives us a complete machine-readable record for later analysis, scripting, or visualization.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`

`lint` still reports the same pre-existing warnings in `src/index.ts` and `src/utils/github.ts`. This PR does not add new lint warnings.