### PR TITLE
Fix bot handoff state and status-comment churn

### DIFF
--- a/.github/workflows/overseer.yml
+++ b/.github/workflows/overseer.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Backstop Sentinel
+      - name: Detect Ignorable Comment Sentinels
         id: backstop_guard
         run: |
           skip_workflow=false
@@ -30,6 +30,9 @@ jobs:
             if printf '%s' "$comment_body" | grep -Fq '<!-- overseer:persistence-backstop -->'; then
               skip_workflow=true
               echo "Skipping workflow because it was triggered by a persistence backstop comment."
+            elif printf '%s' "$comment_body" | grep -Fq '<!-- overseer:status-update -->'; then
+              skip_workflow=true
+              echo "Skipping workflow because it was triggered by a bot status update comment."
             fi
           fi
           echo "skip_workflow=${skip_workflow}" >> "$GITHUB_OUTPUT"

--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -22,6 +22,7 @@ Optional top-level fields:
 
 - `"final_response": "<required when task_status is done>"`
 - `"github_comment": "<markdown progress update to append to the issue thread>"`
+- `"handoff_to": "@planner"` or another explicit next recipient when a done response needs a structured handoff
 
 Rules:
 
@@ -32,7 +33,9 @@ Rules:
   - `{"type":"persist_work"}` for dispatcher-owned persistence when your bot is authorized to publish repository changes
 - If the environment is missing a tool you need, modify `flake.nix` and then continue using `run_shell`.
 - If the task is complete, return `"task_status": "done"`, `"actions": []`, and a non-empty `final_response`.
-- `github_comment`, when present, should be a concise markdown progress update for the issue thread. It is not a substitute for `final_response`.
+- `github_comment`, when present, is for in-progress status only. It is not a substitute for `final_response` and must not contain the final delegation.
+- `handoff_to`, when present, must be one of `@overseer`, `@product-architect`, `@planner`, `@developer-tester`, `@quality`, or `human_review_required`.
+- If you set `handoff_to`, the dispatcher will append the standardized `Next step: ...` line when it posts your final GitHub comment.
 - Do not use markdown fences or prose outside the JSON object.
 
 Example in-progress response object:
@@ -76,6 +79,7 @@ Example done response object:
   "next_step": "Return control to the dispatcher.",
   "actions": [],
   "task_status": "done",
-  "final_response": "Implemented the requested change, ran targeted verification, and confirmed the persisted result on the issue branch."
+  "handoff_to": "@planner",
+  "final_response": "Identified the relevant implementation touchpoints and prepared the planner handoff."
 }
 ```

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -7,4 +7,5 @@ Strict rules:
 3. Do not assign the next action back to the same agent you just received a response from unless human review is required.
 4. If another agent claims to have created or updated files, inspect those files before deciding the next action.
 5. You must never use `persist_work`.
-6. End every delegation with `Next step: @persona to take action`, or `Next step: human review required`.
+6. On every completed response, set `handoff_to` to the explicit next recipient or `human_review_required`.
+7. Put the actual delegation in `final_response`. Do not use `github_comment` for final handoff instructions.

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -3,8 +3,14 @@ import { getBotOrThrow, loadBotRegistry } from "./bots/bot_config.js";
 import { OverseerPersona } from "./personas/overseer.js";
 import { TaskPersona } from "./personas/task_persona.js";
 import type { IterationResult } from "./utils/agent_runner.js";
+import { isWorkflowNoiseComment } from "./utils/comment_markers.js";
 import { GeminiService } from "./utils/gemini.js";
 import { GitHubService } from "./utils/github.js";
+import {
+	buildNextStepLine,
+	resolveNextPersona,
+	stripTrailingNextStep,
+} from "./utils/handoff.js";
 import { PersistenceService } from "./utils/persistence.js";
 import {
 	getAttribution,
@@ -193,6 +199,15 @@ async function run() {
 	} else if (eventName === "issue_comment" && eventData.action === "created") {
 		const body = eventData.comment.body as string;
 		commentUrl = eventData.comment.html_url as string;
+		if (isWorkflowNoiseComment(body)) {
+			logTrace("dispatcher.issueComment.skippedWorkflowNoise", {
+				body: textStats(body),
+			});
+			console.log(
+				"Skipping issue_comment dispatch for workflow noise comment.",
+			);
+			return;
+		}
 
 		// 1. Identify sender persona if bot
 		if (sender === botUser) {
@@ -361,7 +376,6 @@ async function run() {
 				issueNumber,
 				executedPersona,
 				iterationResult,
-				handleMap,
 				personaNameMap,
 				sender,
 				commentUrl,
@@ -378,7 +392,6 @@ async function finalizeRun(
 	issueNumber: number,
 	persona: string,
 	result: IterationResult,
-	handleMap: Record<string, string>,
 	personaNameMap: Record<string, string>,
 	triggeringUser?: string,
 	triggeringCommentUrl?: string,
@@ -389,16 +402,8 @@ async function finalizeRun(
 	fs.writeFileSync(logPath, result.log);
 
 	// 2. Determine Next Persona
-	let nextPersona: string | null = null;
-	if (persona !== "overseer") {
-		nextPersona = "overseer";
-	} else {
-		const nextStepMatch = result.finalResponse.match(/Next step: (@[a-z-]+)/i);
-		if (nextStepMatch) {
-			nextPersona = handleMap[nextStepMatch[1].toLowerCase()] || null;
-			if (nextPersona === "overseer") nextPersona = null;
-		}
-	}
+	const nextPersona = resolveNextPersona(persona, result.handoffTo);
+	const nextStepLine = buildNextStepLine(persona, result.handoffTo);
 
 	// 3. Update State
 	await github.setActivePersona(owner, repo, issueNumber, nextPersona);
@@ -418,8 +423,11 @@ async function finalizeRun(
 		triggeringPersona,
 	);
 
+	const finalBody = stripTrailingNextStep(result.finalResponse);
 	const finalComment =
-		attributionHeader + truncate(result.finalResponse, 50000) + artifactLink;
+		attributionHeader +
+		truncate(`${finalBody}\n\n${nextStepLine}`, 50000) +
+		artifactLink;
 
 	try {
 		await github.addCommentToIssue(owner, repo, issueNumber, finalComment);

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -34,6 +34,7 @@ export class OverseerPersona {
 		issueNumber: number,
 	): AgentRunnerOptions {
 		return {
+			requireDoneHandoff: true,
 			modelName: this.bot.llm.model,
 			promptDefinition: {
 				botId: this.bot.id,

--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -94,6 +94,53 @@ I will comply.
 		expect(parsed.protocol.actions).toHaveLength(2);
 	});
 
+	it("parses optional handoff_to on done responses", () => {
+		const parsed = parseAgentProtocolResponse(
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Delegate to the planner."],
+				next_step: "Return control to the dispatcher.",
+				actions: [],
+				task_status: "done",
+				handoff_to: "@planner",
+				final_response: "Prepared the planner handoff.",
+			}),
+		);
+
+		expect(parsed.protocol.handoff_to).toBe("@planner");
+	});
+
+	it("rejects invalid handoff_to values", () => {
+		expect(() =>
+			parseAgentProtocolResponse(
+				JSON.stringify({
+					version: AGENT_PROTOCOL_VERSION,
+					plan: ["Stop."],
+					next_step: "Stop.",
+					actions: [],
+					task_status: "done",
+					handoff_to: "@not-a-bot",
+					final_response: "Done.",
+				}),
+			),
+		).toThrow(/handoff_to/);
+	});
+
+	it("rejects handoff_to on in-progress responses", () => {
+		expect(() =>
+			parseAgentProtocolResponse(
+				JSON.stringify({
+					version: AGENT_PROTOCOL_VERSION,
+					plan: ["Inspect files."],
+					next_step: "Inspect files.",
+					actions: [{ type: "run_shell", command: "ls" }],
+					task_status: "in_progress",
+					handoff_to: "@planner",
+				}),
+			),
+		).toThrow(/handoff_to/);
+	});
+
 	it("rejects done responses without final_response", () => {
 		expect(() =>
 			parseAgentProtocolResponse(

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -1,6 +1,15 @@
 export const AGENT_PROTOCOL_VERSION = "overseer/v1";
+export const AGENT_HANDOFF_TARGETS = [
+	"@overseer",
+	"@product-architect",
+	"@planner",
+	"@developer-tester",
+	"@quality",
+	"human_review_required",
+] as const;
 
 export type AgentTaskStatus = "in_progress" | "done";
+export type AgentHandoffTarget = (typeof AGENT_HANDOFF_TARGETS)[number];
 
 export interface RunShellAction {
 	type: "run_shell";
@@ -21,6 +30,7 @@ export interface AgentProtocolResponse {
 	task_status: AgentTaskStatus;
 	final_response?: string;
 	github_comment?: string;
+	handoff_to?: AgentHandoffTarget;
 }
 
 export interface ParsedAgentProtocolResponse {
@@ -40,16 +50,22 @@ Work to this workflow on every turn:
 - Use \`"version": "${AGENT_PROTOCOL_VERSION}"\`.
 - Always include \`plan\`, \`next_step\`, \`actions\`, and \`task_status\`.
 - You may include \`github_comment\` as a concise markdown progress update to append to the GitHub issue thread.
+- You may include \`handoff_to\` on \`"done"\` responses to make the next recipient explicit. Valid values: ${AGENT_HANDOFF_TARGETS.map((target) => `\`${target}\``).join(", ")}.
 - If you need to inspect or modify the repository, respond with \`"task_status": "in_progress"\` and at least one action.
 - \`actions\` is an ordered list executed sequentially by the dispatcher.
 - Available actions: \`{"type":"run_shell","command":"..."}\` and \`{"type":"persist_work"}\`.
 - Use \`{"type":"run_shell","command":"..."}\` for repository inspection, file edits, and verification commands.
 - Use \`{"type":"persist_work"}\` only when your persona is authorized to publish repo changes and you want the dispatcher-owned persistence mechanism to commit and push your work.
+- \`github_comment\` is for in-progress status only. Do not put delegation or the final handoff there.
+- If you set \`handoff_to\`, the dispatcher will append the standardized \`Next step: ...\` line when it posts your final GitHub comment.
 - If the task is complete, respond with \`"task_status": "done"\`, \`"actions": []\`, and \`final_response\` containing the concise human-facing summary that should be posted back to GitHub.
 - Do not use \`[RUN:command]\`, markdown fences, or prose outside the JSON object.
 
 Example in-progress response:
 {"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Read the relevant files before editing.","actions":[{"type":"run_shell","command":"cd /project && ls -la"},{"type":"run_shell","command":"cd /project && cat WORKFLOW.md"}],"task_status":"in_progress","github_comment":"Started work and am inspecting the relevant files."}
+
+Example done response:
+{"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Return control to the dispatcher.","actions":[],"task_status":"done","handoff_to":"@planner","final_response":"Identified the relevant implementation touchpoints and prepared the planner handoff."}
 `;
 
 export function buildProtocolRepairMessage(
@@ -115,11 +131,15 @@ export function parseAgentProtocolResponse(
 		record.github_comment,
 		"github_comment",
 	);
+	const handoffTo = parseOptionalHandoffTarget(record.handoff_to);
 
 	if (taskStatus === "in_progress" && actions.length === 0) {
 		throw new Error(
 			'task_status "in_progress" requires at least one action in actions[]',
 		);
+	}
+	if (taskStatus !== "done" && handoffTo) {
+		throw new Error('handoff_to is only valid when task_status is "done"');
 	}
 
 	if (taskStatus === "done") {
@@ -143,6 +163,7 @@ export function parseAgentProtocolResponse(
 			task_status: taskStatus,
 			final_response: finalResponse,
 			github_comment: githubComment,
+			handoff_to: handoffTo,
 		},
 	};
 }
@@ -245,6 +266,21 @@ function parseTaskStatus(value: unknown): AgentTaskStatus {
 		return value;
 	}
 	throw new Error('task_status must be either "in_progress" or "done"');
+}
+
+function parseOptionalHandoffTarget(
+	value: unknown,
+): AgentHandoffTarget | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	const handoffTo = requireNonEmptyString(value, "handoff_to");
+	if (!(AGENT_HANDOFF_TARGETS as readonly string[]).includes(handoffTo)) {
+		throw new Error(
+			`handoff_to must be one of: ${AGENT_HANDOFF_TARGETS.join(", ")}`,
+		);
+	}
+	return handoffTo as AgentHandoffTarget;
 }
 
 function parseActions(value: unknown): AgentAction[] {

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -77,6 +77,7 @@ describe("AgentRunner", () => {
 		expect(result.finalResponse).toBe(
 			"Verified the repository root and completed the task.",
 		);
+		expect(result.handoffTo).toBeUndefined();
 		expect(result.log).toContain("hello");
 		expect(result.log).toContain("world");
 		expect(result.log).toContain("PROTOCOL RESPONSE");
@@ -138,6 +139,7 @@ describe("AgentRunner", () => {
 		);
 
 		expect(result.finalResponse).toContain("Persisted the plan");
+		expect(result.handoffTo).toBeUndefined();
 		expect(result.log).toContain('"commit_sha": "abc123"');
 	});
 
@@ -194,10 +196,64 @@ describe("AgentRunner", () => {
 		);
 
 		expect(postedComments).toEqual([
-			"Started work and am inspecting repository guidance.",
+			expect.stringContaining("<!-- overseer:status-update -->"),
 		]);
+		expect(postedComments[0]).toContain(
+			"Started work and am inspecting repository guidance.",
+		);
 		expect(result.finalResponse).toBe("Completed the requested work.");
 		expect(result.log).toContain("GITHUB COMMENT APPENDED");
+	});
+
+	it("requires a structured handoff when configured", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Hand off the work."],
+				next_step: "Return control to the dispatcher.",
+				actions: [],
+				task_status: "done",
+				final_response: "Delegating to planner.",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Hand off the work."],
+				next_step: "Return control to the dispatcher.",
+				actions: [],
+				task_status: "done",
+				handoff_to: "@planner",
+				final_response: "Delegating to planner.",
+			}),
+		];
+
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage() {
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(makeFakeShell(async () => ""));
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			5,
+			{
+				requireDoneHandoff: true,
+			},
+		);
+
+		expect(result.handoffTo).toBe("@planner");
+		expect(result.finalResponse).toBe("Delegating to planner.");
+		expect(result.log).toContain("PROTOCOL RESPONSE");
 	});
 
 	it("injects top-level AGENTS.md into chat history before the task input", async () => {

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -2,11 +2,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Content } from "@google/generative-ai";
 import {
+	type AgentHandoffTarget,
 	buildContinuationMessage,
 	buildProtocolRepairMessage,
 	type ParsedAgentProtocolResponse,
 	parseAgentProtocolResponse,
 } from "./agent_protocol.js";
+import { prependStatusUpdateSentinel } from "./comment_markers.js";
 import type { GeminiService } from "./gemini.js";
 import type { PersistWorkResult } from "./persistence.js";
 import { ShellService } from "./shell.js";
@@ -14,12 +16,14 @@ import { logTrace, textStats } from "./trace.js";
 
 export interface IterationResult {
 	finalResponse: string;
+	handoffTo?: AgentHandoffTarget;
 	log: string;
 }
 
 export interface AgentRunnerOptions {
 	persistWork?: () => Promise<PersistWorkResult>;
 	appendGithubComment?: (markdown: string) => Promise<void>;
+	requireDoneHandoff?: boolean;
 	modelName?: string;
 	promptDefinition?: {
 		botId: string;
@@ -130,6 +134,7 @@ export class AgentRunner {
 				githubCommentRaw: parsedResponse.protocol.github_comment || "",
 				finalResponse: textStats(parsedResponse.protocol.final_response || ""),
 				finalResponseRaw: parsedResponse.protocol.final_response || "",
+				handoffTo: parsedResponse.protocol.handoff_to,
 			});
 			this.log(`PROTOCOL RESPONSE: ${parsedResponse.rawJson}\n`);
 
@@ -142,8 +147,19 @@ export class AgentRunner {
 			}
 
 			if (parsedResponse.protocol.task_status === "done") {
+				if (options.requireDoneHandoff && !parsedResponse.protocol.handoff_to) {
+					const error =
+						'task_status "done" requires a non-empty handoff_to for this persona';
+					logTrace("agent.iteration.protocolError", {
+						iteration,
+						error,
+					});
+					currentMessage = buildProtocolRepairMessage(error, responseText);
+					continue;
+				}
 				return {
 					finalResponse: parsedResponse.protocol.final_response || "",
+					handoffTo: parsedResponse.protocol.handoff_to,
 					log: this.sessionLog,
 				};
 			}
@@ -231,11 +247,14 @@ export class AgentRunner {
 			return;
 		}
 
-		await options.appendGithubComment(markdown);
+		const commentBody = prependStatusUpdateSentinel(markdown);
+		await options.appendGithubComment(commentBody);
 		logTrace("agent.iteration.githubComment.posted", {
 			iteration,
 			githubComment: textStats(markdown),
 			githubCommentRaw: markdown,
+			commentBody: textStats(commentBody),
+			commentBodyRaw: commentBody,
 		});
 		this.log(`GITHUB COMMENT APPENDED: ${markdown}\n`);
 	}

--- a/src/utils/comment_markers.test.ts
+++ b/src/utils/comment_markers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	hasPersistenceBackstopSentinel,
+	hasStatusUpdateSentinel,
+	isWorkflowNoiseComment,
+	PERSISTENCE_BACKSTOP_SENTINEL,
+	prependStatusUpdateSentinel,
+	STATUS_UPDATE_SENTINEL,
+} from "./comment_markers.js";
+
+describe("comment markers", () => {
+	it("prepends the status update sentinel once", () => {
+		const initial = prependStatusUpdateSentinel("Started work.");
+		const repeated = prependStatusUpdateSentinel(initial);
+
+		expect(initial).toContain(STATUS_UPDATE_SENTINEL);
+		expect(repeated).toBe(initial);
+	});
+
+	it("detects workflow noise comments", () => {
+		expect(
+			hasStatusUpdateSentinel(`${STATUS_UPDATE_SENTINEL}\n\nprogress`),
+		).toBe(true);
+		expect(
+			hasPersistenceBackstopSentinel(
+				`${PERSISTENCE_BACKSTOP_SENTINEL}\n\nbackstop`,
+			),
+		).toBe(true);
+		expect(
+			isWorkflowNoiseComment(`${STATUS_UPDATE_SENTINEL}\n\nprogress`),
+		).toBe(true);
+		expect(
+			isWorkflowNoiseComment(`${PERSISTENCE_BACKSTOP_SENTINEL}\n\nbackstop`),
+		).toBe(true);
+		expect(isWorkflowNoiseComment("normal user comment")).toBe(false);
+	});
+});

--- a/src/utils/comment_markers.ts
+++ b/src/utils/comment_markers.ts
@@ -1,0 +1,26 @@
+export const STATUS_UPDATE_SENTINEL = "<!-- overseer:status-update -->";
+export const PERSISTENCE_BACKSTOP_SENTINEL =
+	"<!-- overseer:persistence-backstop -->";
+
+export function prependStatusUpdateSentinel(markdown: string): string {
+	const trimmed = markdown.trim();
+	if (trimmed.includes(STATUS_UPDATE_SENTINEL)) {
+		return trimmed;
+	}
+	return `${STATUS_UPDATE_SENTINEL}\n\n${trimmed}`;
+}
+
+export function hasStatusUpdateSentinel(markdown: string): boolean {
+	return markdown.includes(STATUS_UPDATE_SENTINEL);
+}
+
+export function hasPersistenceBackstopSentinel(markdown: string): boolean {
+	return markdown.includes(PERSISTENCE_BACKSTOP_SENTINEL);
+}
+
+export function isWorkflowNoiseComment(markdown: string): boolean {
+	return (
+		hasStatusUpdateSentinel(markdown) ||
+		hasPersistenceBackstopSentinel(markdown)
+	);
+}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "@octokit/rest";
+import { isWorkflowNoiseComment } from "./comment_markers.js";
 import { truncate } from "./text.js";
 import { logTrace, textStats } from "./trace.js";
 
@@ -72,7 +73,7 @@ export class GitHubService {
 			if (!Array.isArray(data)) {
 				sha = data.sha;
 			}
-		} catch (error) {
+		} catch (_error) {
 			// File doesn't exist yet, that's fine
 		}
 
@@ -226,7 +227,9 @@ export class GitHubService {
 		context += "--- COMMENTS (Truncated to last 15) ---\n";
 
 		// Only take the last 15 comments to prevent payload explosion
-		const recentComments = comments.data.slice(-15);
+		const recentComments = comments.data
+			.filter((comment) => !isWorkflowNoiseComment(comment.body || ""))
+			.slice(-15);
 
 		for (const comment of recentComments) {
 			const author = comment.user?.login;

--- a/src/utils/handoff.test.ts
+++ b/src/utils/handoff.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildNextStepLine,
+	resolveNextPersona,
+	stripTrailingNextStep,
+} from "./handoff.js";
+
+describe("handoff helpers", () => {
+	it("resolves non-overseer bots back to overseer", () => {
+		expect(resolveNextPersona("planner")).toBe("overseer");
+		expect(buildNextStepLine("planner")).toBe(
+			"Next step: @overseer to take action",
+		);
+	});
+
+	it("resolves overseer handoffs from structured targets", () => {
+		expect(resolveNextPersona("overseer", "@planner")).toBe("planner");
+		expect(buildNextStepLine("overseer", "@planner")).toBe(
+			"Next step: @planner to take action",
+		);
+		expect(resolveNextPersona("overseer", "human_review_required")).toBeNull();
+		expect(buildNextStepLine("overseer", "human_review_required")).toBe(
+			"Next step: human review required",
+		);
+	});
+
+	it("strips a trailing next-step suffix from final text", () => {
+		expect(
+			stripTrailingNextStep(
+				"Implemented the change.\n\nNext step: @planner to take action",
+			),
+		).toBe("Implemented the change.");
+	});
+});

--- a/src/utils/handoff.ts
+++ b/src/utils/handoff.ts
@@ -1,0 +1,45 @@
+import type { AgentHandoffTarget } from "./agent_protocol.js";
+
+export const HANDOFF_TO_PERSONA: Record<
+	Exclude<AgentHandoffTarget, "human_review_required">,
+	string
+> = {
+	"@overseer": "overseer",
+	"@product-architect": "product-architect",
+	"@planner": "planner",
+	"@developer-tester": "developer-tester",
+	"@quality": "quality",
+};
+
+export function stripTrailingNextStep(text: string): string {
+	return text
+		.replace(/\n*\s*Next step: @[a-z-]+ to take action\.?\s*$/i, "")
+		.replace(/\n*\s*Next step: human review required\.?\s*$/i, "")
+		.trim();
+}
+
+export function resolveNextPersona(
+	persona: string,
+	handoffTo?: AgentHandoffTarget,
+): string | null {
+	if (persona !== "overseer") {
+		return "overseer";
+	}
+	if (!handoffTo || handoffTo === "human_review_required") {
+		return null;
+	}
+	return HANDOFF_TO_PERSONA[handoffTo] || null;
+}
+
+export function buildNextStepLine(
+	persona: string,
+	handoffTo?: AgentHandoffTarget,
+): string {
+	if (persona !== "overseer") {
+		return "Next step: @overseer to take action";
+	}
+	if (!handoffTo || handoffTo === "human_review_required") {
+		return "Next step: human review required";
+	}
+	return `Next step: ${handoffTo} to take action`;
+}


### PR DESCRIPTION
## Summary
- make handoff explicit in the agent protocol with `handoff_to`
- use structured handoff state in the dispatcher instead of scraping `final_response`
- mark in-loop `github_comment` updates as ignorable status comments and skip workflows triggered by them
- filter workflow-noise comments out of reconstructed issue context

## Root cause
Issue #53 exposed two coupled problems:
1. Overseer put the real planner handoff in `github_comment`, but the dispatcher only derived the next active persona from `final_response`, so the `active-persona:*` label was cleared instead of set to `planner`.
2. Every in-loop progress comment triggered a fresh `issue_comment` workflow run because those comments were indistinguishable from real handoff comments.

## What changed
- Added optional `handoff_to` to the JSON agent protocol, with validation and examples.
- Require `handoff_to` for completed Overseer responses.
- Have `finalizeRun()` derive the next persona from structured `handoff_to` and append a deterministic `Next step: ...` line itself.
- Wrap `github_comment` progress updates with a hidden `<!-- overseer:status-update -->` sentinel.
- Skip workflow runs triggered by that status-update sentinel, and ignore workflow-noise comments in dispatcher routing and GitHub issue context assembly.

## Validation
- `npm run lint`
- `npm run build`
- `npm test`
