### PR TITLE
[codex] Reinforce intra-bot task context each turn

### DIFF
--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	AGENT_PROTOCOL_VERSION,
+	buildContinuationMessage,
 	parseAgentProtocolResponse,
 } from "./agent_protocol.js";
 
@@ -166,5 +167,33 @@ I will comply.
 				}),
 			),
 		).toThrow(/plan/);
+	});
+
+	it("builds continuation messages that restate task and prior response", () => {
+		const message = buildContinuationMessage({
+			originalTask: "Developer Task:\nTask ID: issue-55",
+			previousResponseJson: JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Read the plan", "Implement the change"],
+				next_step: "Read the plan",
+				actions: [{ type: "run_shell", command: "cat docs/plans/current.md" }],
+				task_status: "in_progress",
+			}),
+			previousGithubComment: "Reading the plan before changing code.",
+			actionOutput:
+				"--- EXECUTING: cat docs/plans/current.md ---\nSTDOUT:\nPlan contents",
+		});
+
+		expect(message).toContain("ORIGINAL TASK:");
+		expect(message).toContain("Task ID: issue-55");
+		expect(message).toContain("MOST RECENT STRUCTURED RESPONSE:");
+		expect(message).toContain('"next_step":"Read the plan"');
+		expect(message).toContain("MOST RECENT GITHUB STATUS COMMENT:");
+		expect(message).toContain("Reading the plan before changing code.");
+		expect(message).toContain("LATEST ACTION OUTPUT:");
+		expect(message).toContain("Plan contents");
+		expect(message).toContain(
+			'Continue the task using protocol "overseer/v1".',
+		);
 	});
 });

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -38,6 +38,13 @@ export interface ParsedAgentProtocolResponse {
 	rawJson: string;
 }
 
+export interface ContinuationContext {
+	originalTask: string;
+	previousResponseJson: string;
+	previousGithubComment?: string;
+	actionOutput: string;
+}
+
 export const AGENT_PROTOCOL_PROMPT = `
 RESPONSE PROTOCOL:
 Work to this workflow on every turn:
@@ -81,11 +88,27 @@ export function buildProtocolRepairMessage(
 	].join("\n\n");
 }
 
-export function buildContinuationMessage(actionOutput: string): string {
+export function buildContinuationMessage({
+	originalTask,
+	previousResponseJson,
+	previousGithubComment,
+	actionOutput,
+}: ContinuationContext): string {
 	return [
-		"ACTION OUTPUT:",
+		"ORIGINAL TASK:",
+		originalTask,
+		"",
+		"MOST RECENT STRUCTURED RESPONSE:",
+		previousResponseJson,
+		"",
+		...(previousGithubComment
+			? ["MOST RECENT GITHUB STATUS COMMENT:", previousGithubComment, ""]
+			: []),
+		"LATEST ACTION OUTPUT:",
 		actionOutput,
 		"",
+		"Continue the same task. Do not restart or reinterpret the assignment.",
+		"Use the original task and your most recent structured response to decide the next step.",
 		`Continue the task using protocol "${AGENT_PROTOCOL_VERSION}".`,
 		"Return exactly one JSON object.",
 	].join("\n");

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -38,11 +38,13 @@ describe("AgentRunner", () => {
 				final_response: "Verified the repository root and completed the task.",
 			}),
 		];
+		const sentMessages: string[] = [];
 
 		const gemini = {
 			startChat() {
 				return {
-					async sendMessage() {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
 						const next = responses.shift();
 						if (!next) {
 							throw new Error("No more responses queued");
@@ -81,6 +83,17 @@ describe("AgentRunner", () => {
 		expect(result.log).toContain("hello");
 		expect(result.log).toContain("world");
 		expect(result.log).toContain("PROTOCOL RESPONSE");
+		expect(sentMessages).toHaveLength(2);
+		expect(sentMessages[0]).toBe("Initial message");
+		expect(sentMessages[1]).toContain("ORIGINAL TASK:");
+		expect(sentMessages[1]).toContain("Initial message");
+		expect(sentMessages[1]).toContain("MOST RECENT STRUCTURED RESPONSE:");
+		expect(sentMessages[1]).toContain(
+			'"next_step":"Inspect the repository root."',
+		);
+		expect(sentMessages[1]).toContain("LATEST ACTION OUTPUT:");
+		expect(sentMessages[1]).toContain("hello");
+		expect(sentMessages[1]).toContain("world");
 	});
 
 	it("executes persist_work actions through the injected callback", async () => {

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -83,6 +83,7 @@ export class AgentRunner {
 			repositoryGuidance.history,
 			options.modelName,
 		);
+		const originalTask = initialMessage;
 		let currentMessage = initialMessage;
 		let iteration = 0;
 
@@ -176,7 +177,12 @@ export class AgentRunner {
 				actionOutput: textStats(actionOutput),
 			});
 			this.log(`ACTION OUTPUT: ${actionOutput}\n`);
-			currentMessage = buildContinuationMessage(actionOutput);
+			currentMessage = buildContinuationMessage({
+				originalTask,
+				previousResponseJson: parsedResponse.rawJson,
+				previousGithubComment: parsedResponse.protocol.github_comment,
+				actionOutput,
+			});
 		}
 
 		logTrace("agent.loop.maxIterationsReached", {


### PR DESCRIPTION
## Summary
- keep the original task visible on every continuation turn
- include the bot's most recent structured JSON response and latest status comment in the next prompt
- add tests proving iteration 2 still sees the original assignment and prior protocol state

## Why
Issue #55 showed that task bots received a good initial handoff but then drifted after the first turn because later prompts only contained raw action output plus a generic continue instruction. This change keeps the running assignment and prior structured state reinforced throughout the same chat session.

## Validation
- npm run build
- npm test
- npm run lint

Lint still reports the same two pre-existing warnings in `src/index.ts` and `src/utils/github.ts`.
