### PR TITLE
[codex] Add read-only shell capabilities for review bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .env
 *.log
+trace_*.jsonl

--- a/SHELL_CAPABILITIES.md
+++ b/SHELL_CAPABILITIES.md
@@ -1,0 +1,34 @@
+## Goal
+
+Split shell access into a read-only path for every bot and a read-write path only for bots that are allowed to modify the repository.
+
+## Design
+
+- Add `trace_*.jsonl` to `.gitignore` so trace artifacts do not become candidate bot output.
+- Add `shell_access` to `bots.json` with two values:
+  - `read_only`
+  - `read_write`
+- Add a new protocol action:
+  - `{"type":"run_ro_shell","command":"..."}`
+- Keep `{"type":"run_shell","command":"..."}` only for read-write bots.
+- Keep `persist_work` separate from shell access. A bot may be read-write and still be forbidden from publishing changes.
+
+## Runtime Behavior
+
+- `run_ro_shell` executes inside `nix develop -c` in a disposable read-only clone of the current repository.
+- The clone's working tree is made non-writable before command execution.
+- Temporary files, HOME, and TMPDIR live outside the read-only tree so normal inspection tools still work.
+- `run_shell` continues to execute inside the live repository checkout and is available only to bots with `shell_access: "read_write"`.
+- The runner must reject any action the current bot is not authorized to use.
+
+## Prompting
+
+- Shared protocol docs must describe both shell actions.
+- Read-only bots must be told to use `run_ro_shell` for inspection and verification only.
+- Read-write bots must be told to use `run_ro_shell` for inspection and `run_shell` when they intentionally need to edit repository files.
+- All prompt text should make it explicit that the environment is a Nix-based Linux environment and that `flake.nix` is the place to change tooling.
+
+## Scope
+
+- This change does not introduce a general OS sandbox or network isolation layer.
+- The protection target is the repository working tree. The read-only shell should prevent writes there, which is the failure mode that confused Overseer and other review bots.

--- a/bots.json
+++ b/bots.json
@@ -16,6 +16,7 @@
       "id": "overseer",
       "display_name": "Overseer",
       "kind": "overseer",
+      "shell_access": "read_only",
       "allow_persist_work": false,
       "prompt_files": [
         "prompts/shared/overseer-core.md",
@@ -26,6 +27,7 @@
       "id": "product-architect",
       "display_name": "Product/Architect",
       "kind": "task",
+      "shell_access": "read_write",
       "allow_persist_work": true,
       "prompt_files": [
         "prompts/shared/task-agent.md",
@@ -37,6 +39,7 @@
       "id": "planner",
       "display_name": "Planner",
       "kind": "task",
+      "shell_access": "read_write",
       "allow_persist_work": true,
       "prompt_files": [
         "prompts/shared/task-agent.md",
@@ -48,6 +51,7 @@
       "id": "developer-tester",
       "display_name": "Developer/Tester",
       "kind": "task",
+      "shell_access": "read_write",
       "allow_persist_work": true,
       "prompt_files": [
         "prompts/shared/task-agent.md",
@@ -60,6 +64,7 @@
       "id": "quality",
       "display_name": "Quality",
       "kind": "task",
+      "shell_access": "read_only",
       "allow_persist_work": false,
       "prompt_files": [
         "prompts/shared/task-agent.md",

--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -29,9 +29,8 @@ Rules:
 - If you need to inspect or modify the repository, return `"task_status": "in_progress"` and at least one action.
 - `actions` is an ordered list. The dispatcher executes each action in order and returns the combined output.
 - Available action types:
-  - `{"type":"run_shell","command":"..."}` for repository inspection, file edits, and verification commands. These commands run inside the repository's default `nix develop -c` environment automatically.
-  - `{"type":"persist_work"}` for dispatcher-owned persistence when your bot is authorized to publish repository changes
-- If the environment is missing a tool you need, modify `flake.nix` and then continue using `run_shell`.
+{{AVAILABLE_ACTIONS_BULLETS}}
+{{SHELL_ACTION_RULES}}
 - If the task is complete, return `"task_status": "done"`, `"actions": []`, and a non-empty `final_response`.
 - `github_comment`, when present, is for in-progress status only. It is not a substitute for `final_response` and must not contain the final delegation.
 - `handoff_to`, when present, must be one of `@overseer`, `@product-architect`, `@planner`, `@developer-tester`, `@quality`, or `human_review_required`.
@@ -50,16 +49,7 @@ Example in-progress response object:
     "Persist the work and confirm it exists on the issue branch."
   ],
   "next_step": "Read WORKFLOW.md and the referenced plan file before changing code.",
-  "actions": [
-    {
-      "type": "run_shell",
-      "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
-    },
-    {
-      "type": "run_shell",
-      "command": "cat docs/plans/current-plan.md"
-    }
-  ],
+  "actions": {{IN_PROGRESS_EXAMPLE_ACTIONS}},
   "task_status": "in_progress",
   "github_comment": "Started work on the assigned task and am reading the required repository guidance first."
 }

--- a/prompts/shared/github-actions.md
+++ b/prompts/shared/github-actions.md
@@ -1,6 +1,7 @@
 Assume you are running in automation inside a Nix-based Linux environment:
 
-- `run_shell` commands are executed inside `nix develop -c` by default, so do not wrap them in `nix develop` yourself unless you are intentionally doing something unusual
+- `run_ro_shell` commands are executed inside `nix develop -c` in a disposable read-only repository clone, so use them for inspection and verification
+- if your bot is authorized to use `run_shell`, those commands are executed inside `nix develop -c` in the live repository checkout
 - if you need to add or change tools in the environment, edit `flake.nix` rather than using ad hoc package installation
 
 - inspect the repository directly instead of guessing

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -7,5 +7,6 @@ Strict rules:
 3. Do not assign the next action back to the same agent you just received a response from unless human review is required.
 4. If another agent claims to have created or updated files, inspect those files before deciding the next action.
 5. You must never use `persist_work`.
-6. On every completed response, set `handoff_to` to the explicit next recipient or `human_review_required`.
-7. Put the actual delegation in `final_response`. Do not use `github_comment` for final handoff instructions.
+6. Use `run_ro_shell` for inspection. Do not use `run_shell`.
+7. On every completed response, set `handoff_to` to the explicit next recipient or `human_review_required`.
+8. Put the actual delegation in `final_response`. Do not use `github_comment` for final handoff instructions.

--- a/prompts/shared/persisting-agent.md
+++ b/prompts/shared/persisting-agent.md
@@ -1,5 +1,7 @@
 You are authorized to modify repository files.
 
+Use `run_ro_shell` for inspection by default and `run_shell` when you intentionally need to modify repository files.
+
 When your work is ready, call `{"type":"persist_work"}`.
 
 Do not run `git commit` or `git push` yourself.

--- a/prompts/shared/read-only-agent.md
+++ b/prompts/shared/read-only-agent.md
@@ -2,4 +2,6 @@ You are not authorized to publish repository changes.
 
 Do not use `persist_work`.
 
-Use shell actions only for inspection, verification, and review-oriented commands.
+Use `run_ro_shell` only for inspection, verification, and review-oriented commands.
+
+Do not use `run_shell`.

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -4,6 +4,6 @@ The dynamic task input is the canonical assignment. Do not wait for a second hid
 
 If the task references files to read first, read those files before broader exploration.
 
-Use the JSON action protocol to inspect the repository, make changes, and verify results.
+Use the JSON action protocol to inspect the repository, verify results, and make changes only when your available actions permit it.
 
 Do not delegate. Complete the task you were given and return control to the dispatcher.

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -7,6 +7,7 @@ describe("bot_config", () => {
 		const developer = getBotOrThrow(registry, "developer-tester");
 
 		expect(developer.kind).toBe("task");
+		expect(developer.shellAccess).toBe("read_write");
 		expect(developer.allowPersistWork).toBe(true);
 		expect(developer.prompt.promptFiles).toContain(
 			"prompts/shared/agent-protocol.md",
@@ -20,6 +21,10 @@ describe("bot_config", () => {
 		expect(developer.prompt.concatenatedPrompt).toContain(
 			"You implement code and verification for the assigned task.",
 		);
+		expect(developer.prompt.concatenatedPrompt).toContain(
+			'"type":"run_ro_shell"',
+		);
+		expect(developer.prompt.concatenatedPrompt).toContain('"type":"run_shell"');
 		expect(developer.prompt.concatenatedPrompt).not.toContain(
 			"BEGIN PROMPT FILE:",
 		);
@@ -29,7 +34,11 @@ describe("bot_config", () => {
 		const registry = loadBotRegistry();
 
 		expect(getBotOrThrow(registry, "overseer").kind).toBe("overseer");
+		expect(getBotOrThrow(registry, "quality").shellAccess).toBe("read_only");
 		expect(getBotOrThrow(registry, "quality").allowPersistWork).toBe(false);
+		expect(
+			getBotOrThrow(registry, "quality").prompt.concatenatedPrompt,
+		).toContain("Do not use `run_shell`.");
 		expect(registry.all).toHaveLength(5);
 	});
 });

--- a/src/bots/bot_config.ts
+++ b/src/bots/bot_config.ts
@@ -5,6 +5,7 @@ import { textStats } from "../utils/trace.js";
 
 export type BotKind = "overseer" | "task";
 export type LlmProvider = "gemini";
+export type ShellAccess = "read_only" | "read_write";
 
 interface RawBotManifest {
 	defaults?: {
@@ -22,6 +23,7 @@ interface RawBotDefinition {
 	id?: string;
 	display_name?: string;
 	kind?: string;
+	shell_access?: string;
 	llm?: {
 		provider?: string;
 		model?: string;
@@ -45,6 +47,7 @@ export interface LoadedBotDefinition {
 		provider: LlmProvider;
 		model: string;
 	};
+	shellAccess: ShellAccess;
 	allowPersistWork: boolean;
 	maxIterations: number;
 	prompt: LoadedPromptAssembly;
@@ -124,6 +127,7 @@ function loadBotDefinition(
 		`${id}.display_name`,
 	);
 	const kind = parseKind(rawBot.kind, id);
+	const shellAccess = parseShellAccess(rawBot.shell_access, id);
 	const provider = parseProvider(
 		rawBot.llm?.provider || defaults.defaultProvider,
 		`${id}.llm.provider`,
@@ -153,15 +157,23 @@ function loadBotDefinition(
 			provider,
 			model,
 		},
+		shellAccess,
 		allowPersistWork,
 		maxIterations,
-		prompt: loadPromptAssembly(repoRoot, promptFiles),
+		prompt: loadPromptAssembly(repoRoot, promptFiles, {
+			shellAccess,
+			allowPersistWork,
+		}),
 	};
 }
 
 function loadPromptAssembly(
 	repoRoot: string,
 	promptFiles: string[],
+	context: {
+		shellAccess: ShellAccess;
+		allowPersistWork: boolean;
+	},
 ): LoadedPromptAssembly {
 	const duplicatePromptFiles = findDuplicates(promptFiles);
 	if (duplicatePromptFiles.length > 0) {
@@ -173,7 +185,10 @@ function loadPromptAssembly(
 	const promptFileContents: Record<string, string> = {};
 	const sections = promptFiles.map((promptFile) => {
 		const absolutePath = resolve(repoRoot, promptFile);
-		const content = renderPromptTemplate(readFileSync(absolutePath, "utf8"));
+		const content = renderPromptTemplate(
+			readFileSync(absolutePath, "utf8"),
+			context,
+		);
 		promptFileContents[promptFile] = content;
 		return content.trimEnd();
 	});
@@ -185,11 +200,24 @@ function loadPromptAssembly(
 	};
 }
 
-function renderPromptTemplate(content: string): string {
-	return content.replaceAll(
-		"{{AGENT_PROTOCOL_VERSION}}",
-		AGENT_PROTOCOL_VERSION,
-	);
+function renderPromptTemplate(
+	content: string,
+	context: {
+		shellAccess: ShellAccess;
+		allowPersistWork: boolean;
+	},
+): string {
+	return content
+		.replaceAll("{{AGENT_PROTOCOL_VERSION}}", AGENT_PROTOCOL_VERSION)
+		.replaceAll(
+			"{{AVAILABLE_ACTIONS_BULLETS}}",
+			buildAvailableActionsBullets(context),
+		)
+		.replaceAll(
+			"{{IN_PROGRESS_EXAMPLE_ACTIONS}}",
+			buildExampleActionsJson(context),
+		)
+		.replaceAll("{{SHELL_ACTION_RULES}}", buildShellActionRules(context));
 }
 
 function parseKind(value: string | undefined, fieldPrefix: string): BotKind {
@@ -197,6 +225,18 @@ function parseKind(value: string | undefined, fieldPrefix: string): BotKind {
 		return value;
 	}
 	throw new Error(`${fieldPrefix}.kind must be "overseer" or "task"`);
+}
+
+function parseShellAccess(
+	value: string | undefined,
+	fieldPrefix: string,
+): ShellAccess {
+	if (value === "read_only" || value === "read_write") {
+		return value;
+	}
+	throw new Error(
+		`${fieldPrefix}.shell_access must be "read_only" or "read_write"`,
+	);
 }
 
 function parseProvider(
@@ -236,6 +276,86 @@ function findDuplicates(values: string[]): string[] {
 		seen.add(value);
 	}
 	return [...duplicates];
+}
+
+function buildAvailableActionsBullets(context: {
+	shellAccess: ShellAccess;
+	allowPersistWork: boolean;
+}): string {
+	const bullets = [
+		'- `{"type":"run_ro_shell","command":"..."}` for repository inspection and verification commands inside a disposable read-only clone of the repository. This command runs inside the repository\'s default `nix develop -c` environment automatically.',
+	];
+
+	if (context.shellAccess === "read_write") {
+		bullets.push(
+			'- `{"type":"run_shell","command":"..."}` for repository edits and verification commands in the live repository checkout. This command also runs inside the repository\'s default `nix develop -c` environment automatically.',
+		);
+	} else {
+		bullets.push(
+			"- `run_shell` is not available to this bot. Stay inside `run_ro_shell` and do not attempt repository writes.",
+		);
+	}
+
+	if (context.allowPersistWork) {
+		bullets.push(
+			'- `{"type":"persist_work"}` for dispatcher-owned persistence when your bot is authorized to publish repository changes.',
+		);
+	} else {
+		bullets.push(
+			"- `persist_work` is not available to this bot unless the dispatcher explicitly enables it.",
+		);
+	}
+
+	return bullets.join("\n");
+}
+
+function buildExampleActionsJson(context: {
+	shellAccess: ShellAccess;
+	allowPersistWork: boolean;
+}): string {
+	const actions =
+		context.shellAccess === "read_write"
+			? `[
+    {
+      "type": "run_ro_shell",
+      "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
+    },
+    {
+      "type": "run_shell",
+      "command": "cat docs/plans/current-plan.md"
+    }
+  ]`
+			: `[
+    {
+      "type": "run_ro_shell",
+      "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
+    },
+    {
+      "type": "run_ro_shell",
+      "command": "cat docs/plans/current-plan.md"
+    }
+  ]`;
+
+	return actions;
+}
+
+function buildShellActionRules(context: {
+	shellAccess: ShellAccess;
+	allowPersistWork: boolean;
+}): string {
+	if (context.shellAccess === "read_write") {
+		return [
+			"- `run_ro_shell` is the default choice for inspection and verification.",
+			"- Use `run_shell` only when you intentionally need to modify repository files or run write-dependent project tooling.",
+			"- If the environment is missing a tool you need, edit `flake.nix` and then continue using the shell actions above.",
+		].join("\n");
+	}
+
+	return [
+		"- Use `run_ro_shell` for inspection and verification only.",
+		"- `run_shell` is unavailable to this bot.",
+		"- If the environment is missing a tool you need, note that in your output instead of trying to modify the repository or tooling configuration yourself.",
+	].join("\n");
 }
 
 export function summarizePromptAssembly(prompt: LoadedPromptAssembly) {

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -36,6 +36,7 @@ export class OverseerPersona {
 		return {
 			requireDoneHandoff: true,
 			modelName: this.bot.llm.model,
+			shellAccess: this.bot.shellAccess,
 			promptDefinition: {
 				botId: this.bot.id,
 				displayName: this.bot.displayName,

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -48,6 +48,7 @@ export class TaskPersona {
 			issueNumber,
 			taskBody: textStats(taskBody),
 			taskBodyRaw: taskBody,
+			shellAccess: this.bot.shellAccess,
 			allowPersistWork: this.bot.allowPersistWork,
 			maxIterations: this.bot.maxIterations,
 			llm: this.bot.llm,
@@ -56,6 +57,7 @@ export class TaskPersona {
 
 		const runnerOptions: AgentRunnerOptions = {
 			modelName: this.bot.llm.model,
+			shellAccess: this.bot.shellAccess,
 			promptDefinition: {
 				botId: this.bot.id,
 				displayName: this.bot.displayName,

--- a/src/scripts/inspect_bots.test.ts
+++ b/src/scripts/inspect_bots.test.ts
@@ -14,6 +14,8 @@ describe("inspect_bots", () => {
 		expect(markdown).toContain("# Bots");
 		expect(markdown).toContain("| `overseer` | Overseer |");
 		expect(markdown).toContain("| `developer-tester` | Developer/Tester |");
+		expect(markdown).toContain("| `read_only` |");
+		expect(markdown).toContain("| `read_write` |");
 	});
 
 	it("renders detail for a specific bot including prompt files and contents", () => {
@@ -22,6 +24,7 @@ describe("inspect_bots", () => {
 		const markdown = renderBotDetailMarkdown(bot);
 
 		expect(markdown).toContain("# Developer/Tester");
+		expect(markdown).toContain("Shell Access: `read_write`");
 		expect(markdown).toContain("## Prompt Files");
 		expect(markdown).toContain("`prompts/shared/developer-guidance.md`");
 		expect(markdown).toContain("## Concatenated Prompt");

--- a/src/scripts/inspect_bots.ts
+++ b/src/scripts/inspect_bots.ts
@@ -38,11 +38,11 @@ export function renderBotListMarkdown(bots: LoadedBotDefinition[]): string {
 	const lines = [
 		"# Bots",
 		"",
-		"| ID | Name | Kind | Model | Persist | Prompt Files |",
-		"| --- | --- | --- | --- | --- | ---: |",
+		"| ID | Name | Kind | Shell | Model | Persist | Prompt Files |",
+		"| --- | --- | --- | --- | --- | --- | ---: |",
 		...bots.map(
 			(bot) =>
-				`| \`${bot.id}\` | ${bot.displayName} | \`${bot.kind}\` | \`${bot.llm.model}\` | ${bot.allowPersistWork ? "yes" : "no"} | ${bot.prompt.promptFiles.length} |`,
+				`| \`${bot.id}\` | ${bot.displayName} | \`${bot.kind}\` | \`${bot.shellAccess}\` | \`${bot.llm.model}\` | ${bot.allowPersistWork ? "yes" : "no"} | ${bot.prompt.promptFiles.length} |`,
 		),
 		"",
 		"Usage:",
@@ -61,6 +61,7 @@ export function renderBotDetailMarkdown(bot: LoadedBotDefinition): string {
 		"",
 		`- ID: \`${bot.id}\``,
 		`- Kind: \`${bot.kind}\``,
+		`- Shell Access: \`${bot.shellAccess}\``,
 		`- Provider: \`${bot.llm.provider}\``,
 		`- Model: \`${bot.llm.model}\``,
 		`- Persist Work: ${bot.allowPersistWork ? "yes" : "no"}`,

--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -12,14 +12,14 @@ describe("parseAgentProtocolResponse", () => {
 				version: AGENT_PROTOCOL_VERSION,
 				plan: ["Inspect the repository root."],
 				next_step: "Inspect the repository root.",
-				actions: [{ type: "run_shell", command: "ls -la" }],
+				actions: [{ type: "run_ro_shell", command: "ls -la" }],
 				task_status: "in_progress",
 			}),
 		);
 
 		expect(parsed.protocol.task_status).toBe("in_progress");
 		expect(parsed.protocol.actions).toEqual([
-			{ type: "run_shell", command: "ls -la" },
+			{ type: "run_ro_shell", command: "ls -la" },
 		]);
 	});
 
@@ -46,14 +46,30 @@ I will comply.
   "version": "${AGENT_PROTOCOL_VERSION}",
   "plan": ["Review shell output."],
   "next_step": "Review shell output.",
- "actions": [{"type": "run_shell", "command": "cat package.json"}],
+ "actions": [{"type": "run_ro_shell", "command": "cat package.json"}],
   "task_status": "in_progress"
 }`);
 
 		expect(parsed.protocol.actions[0]).toEqual({
-			type: "run_shell",
+			type: "run_ro_shell",
 			command: "cat package.json",
 		});
+	});
+
+	it("parses run_shell actions", () => {
+		const parsed = parseAgentProtocolResponse(
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the target file."],
+				next_step: "Edit the target file.",
+				actions: [{ type: "run_shell", command: "printf ok >> target.txt" }],
+				task_status: "in_progress",
+			}),
+		);
+
+		expect(parsed.protocol.actions).toEqual([
+			{ type: "run_shell", command: "printf ok >> target.txt" },
+		]);
 	});
 
 	it("parses persist_work actions", () => {
@@ -77,8 +93,8 @@ I will comply.
 				plan: ["Read repository guidance", "Implement the task"],
 				next_step: "Read WORKFLOW.md.",
 				actions: [
-					{ type: "run_shell", command: "cat WORKFLOW.md" },
-					{ type: "run_shell", command: "cat docs/plans/current-plan.md" },
+					{ type: "run_ro_shell", command: "cat WORKFLOW.md" },
+					{ type: "run_ro_shell", command: "cat docs/plans/current-plan.md" },
 				],
 				task_status: "in_progress",
 				github_comment: "Started work and am reading repository guidance.",
@@ -134,7 +150,7 @@ I will comply.
 					version: AGENT_PROTOCOL_VERSION,
 					plan: ["Inspect files."],
 					next_step: "Inspect files.",
-					actions: [{ type: "run_shell", command: "ls" }],
+					actions: [{ type: "run_ro_shell", command: "ls" }],
 					task_status: "in_progress",
 					handoff_to: "@planner",
 				}),
@@ -162,7 +178,7 @@ I will comply.
 				JSON.stringify({
 					version: AGENT_PROTOCOL_VERSION,
 					next_step: "Inspect files.",
-					actions: [{ type: "run_shell", command: "ls" }],
+					actions: [{ type: "run_ro_shell", command: "ls" }],
 					task_status: "in_progress",
 				}),
 			),
@@ -176,7 +192,9 @@ I will comply.
 				version: AGENT_PROTOCOL_VERSION,
 				plan: ["Read the plan", "Implement the change"],
 				next_step: "Read the plan",
-				actions: [{ type: "run_shell", command: "cat docs/plans/current.md" }],
+				actions: [
+					{ type: "run_ro_shell", command: "cat docs/plans/current.md" },
+				],
 				task_status: "in_progress",
 			}),
 			previousGithubComment: "Reading the plan before changing code.",

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -11,6 +11,11 @@ export const AGENT_HANDOFF_TARGETS = [
 export type AgentTaskStatus = "in_progress" | "done";
 export type AgentHandoffTarget = (typeof AGENT_HANDOFF_TARGETS)[number];
 
+export interface RunReadOnlyShellAction {
+	type: "run_ro_shell";
+	command: string;
+}
+
 export interface RunShellAction {
 	type: "run_shell";
 	command: string;
@@ -20,7 +25,10 @@ export interface PersistWorkAction {
 	type: "persist_work";
 }
 
-export type AgentAction = RunShellAction | PersistWorkAction;
+export type AgentAction =
+	| RunReadOnlyShellAction
+	| RunShellAction
+	| PersistWorkAction;
 
 export interface AgentProtocolResponse {
 	version: typeof AGENT_PROTOCOL_VERSION;
@@ -60,8 +68,9 @@ Work to this workflow on every turn:
 - You may include \`handoff_to\` on \`"done"\` responses to make the next recipient explicit. Valid values: ${AGENT_HANDOFF_TARGETS.map((target) => `\`${target}\``).join(", ")}.
 - If you need to inspect or modify the repository, respond with \`"task_status": "in_progress"\` and at least one action.
 - \`actions\` is an ordered list executed sequentially by the dispatcher.
-- Available actions: \`{"type":"run_shell","command":"..."}\` and \`{"type":"persist_work"}\`.
-- Use \`{"type":"run_shell","command":"..."}\` for repository inspection, file edits, and verification commands.
+- Available actions: \`{"type":"run_ro_shell","command":"..."}\`, \`{"type":"run_shell","command":"..."}\`, and \`{"type":"persist_work"}\`.
+- Use \`{"type":"run_ro_shell","command":"..."}\` for repository inspection and verification commands.
+- Use \`{"type":"run_shell","command":"..."}\` for repository file edits and verification commands when your persona is authorized to modify the live checkout.
 - Use \`{"type":"persist_work"}\` only when your persona is authorized to publish repo changes and you want the dispatcher-owned persistence mechanism to commit and push your work.
 - \`github_comment\` is for in-progress status only. Do not put delegation or the final handoff there.
 - If you set \`handoff_to\`, the dispatcher will append the standardized \`Next step: ...\` line when it posts your final GitHub comment.
@@ -69,7 +78,7 @@ Work to this workflow on every turn:
 - Do not use \`[RUN:command]\`, markdown fences, or prose outside the JSON object.
 
 Example in-progress response:
-{"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Read the relevant files before editing.","actions":[{"type":"run_shell","command":"cd /project && ls -la"},{"type":"run_shell","command":"cd /project && cat WORKFLOW.md"}],"task_status":"in_progress","github_comment":"Started work and am inspecting the relevant files."}
+{"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Read the relevant files before editing.","actions":[{"type":"run_ro_shell","command":"cd /project && ls -la"},{"type":"run_shell","command":"cd /project && cat WORKFLOW.md"}],"task_status":"in_progress","github_comment":"Started work and am inspecting the relevant files."}
 
 Example done response:
 {"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Return control to the dispatcher.","actions":[],"task_status":"done","handoff_to":"@planner","final_response":"Identified the relevant implementation touchpoints and prepared the planner handoff."}
@@ -321,6 +330,16 @@ function parseAction(value: unknown, index: number): AgentAction {
 
 	const record = value as Record<string, unknown>;
 	const type = requireNonEmptyString(record.type, `actions[${index}].type`);
+	if (type === "run_ro_shell") {
+		return {
+			type: "run_ro_shell",
+			command: requireNonEmptyString(
+				record.command,
+				`actions[${index}].command`,
+			),
+		};
+	}
+
 	if (type === "run_shell") {
 		return {
 			type: "run_shell",
@@ -338,7 +357,7 @@ function parseAction(value: unknown, index: number): AgentAction {
 	}
 
 	throw new Error(
-		`actions[${index}].type must be "run_shell" or "persist_work"`,
+		`actions[${index}].type must be "run_ro_shell", "run_shell", or "persist_work"`,
 	);
 }
 

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -24,7 +24,7 @@ describe("AgentRunner", () => {
 				plan: ["Inspect the repository root.", "Return control."],
 				next_step: "Inspect the repository root.",
 				actions: [
-					{ type: "run_shell", command: "printf 'hello'" },
+					{ type: "run_ro_shell", command: "printf 'hello'" },
 					{ type: "run_shell", command: "printf 'world'" },
 				],
 				task_status: "in_progress",
@@ -58,8 +58,12 @@ describe("AgentRunner", () => {
 		const shell = makeFakeShell(async (actions) =>
 			actions
 				.filter(
-					(action): action is Extract<AgentAction, { type: "run_shell" }> =>
-						action.type === "run_shell",
+					(
+						action,
+					): action is Extract<
+						AgentAction,
+						{ type: "run_shell" | "run_ro_shell" }
+					> => action.type === "run_shell" || action.type === "run_ro_shell",
 				)
 				.map(
 					(action) =>
@@ -74,6 +78,9 @@ describe("AgentRunner", () => {
 			"System instruction",
 			"Initial message",
 			5,
+			{
+				shellAccess: "read_write",
+			},
 		);
 
 		expect(result.finalResponse).toBe(
@@ -162,7 +169,7 @@ describe("AgentRunner", () => {
 				version: AGENT_PROTOCOL_VERSION,
 				plan: ["Inspect WORKFLOW.md.", "Return control."],
 				next_step: "Inspect WORKFLOW.md.",
-				actions: [{ type: "run_shell", command: "printf 'ok'" }],
+				actions: [{ type: "run_ro_shell", command: "printf 'ok'" }],
 				task_status: "in_progress",
 				github_comment: "Started work and am inspecting repository guidance.",
 			}),
@@ -216,6 +223,54 @@ describe("AgentRunner", () => {
 		);
 		expect(result.finalResponse).toBe("Completed the requested work.");
 		expect(result.log).toContain("GITHUB COMMENT APPENDED");
+	});
+
+	it("rejects run_shell for read-only personas", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect files safely.", "Return control."],
+				next_step: "Inspect files safely.",
+				actions: [{ type: "run_shell", command: "printf 'nope' > file.txt" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect files safely.", "Return control."],
+				next_step: "Return control to the dispatcher.",
+				actions: [],
+				task_status: "done",
+				final_response: "Returned control after the rejected action.",
+			}),
+		];
+
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage() {
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(makeFakeShell(async () => ""));
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			5,
+			{
+				shellAccess: "read_only",
+			},
+		);
+
+		expect(result.log).toContain("run_shell_not_available");
+		expect(result.finalResponse).toContain("Returned control");
 	});
 
 	it("requires a structured handoff when configured", async () => {

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -11,6 +11,7 @@ import {
 import { prependStatusUpdateSentinel } from "./comment_markers.js";
 import type { GeminiService } from "./gemini.js";
 import type { PersistWorkResult } from "./persistence.js";
+import type { ShellExecutionMode } from "./shell.js";
 import { ShellService } from "./shell.js";
 import { logTrace, textStats } from "./trace.js";
 
@@ -25,6 +26,7 @@ export interface AgentRunnerOptions {
 	appendGithubComment?: (markdown: string) => Promise<void>;
 	requireDoneHandoff?: boolean;
 	modelName?: string;
+	shellAccess?: ShellExecutionMode;
 	promptDefinition?: {
 		botId: string;
 		displayName: string;
@@ -208,9 +210,31 @@ export class AgentRunner {
 		}
 
 		const outputs: string[] = [];
+		const shellAccess = options.shellAccess ?? "read_write";
 
 		for (const action of actions) {
+			if (action.type === "run_ro_shell") {
+				outputs.push(await this.shell.executeActions([action]));
+				continue;
+			}
+
 			if (action.type === "run_shell") {
+				if (shellAccess !== "read_write") {
+					outputs.push(
+						JSON.stringify(
+							{
+								ok: false,
+								error_code: "run_shell_not_available",
+								message:
+									'run_shell is not available for this persona. Use "run_ro_shell" instead.',
+							},
+							null,
+							2,
+						),
+					);
+					continue;
+				}
+
 				outputs.push(await this.shell.executeActions([action]));
 				continue;
 			}
@@ -221,8 +245,7 @@ export class AgentRunner {
 						{
 							ok: false,
 							error_code: "persist_not_available",
-							message:
-								'persist_work is not available for this persona. Use "run_shell" instead.',
+							message: "persist_work is not available for this persona.",
 						},
 						null,
 						2,

--- a/src/utils/shell.test.ts
+++ b/src/utils/shell.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { wrapInNixDevelop } from "./shell.js";
+import { ShellService, wrapInNixDevelop } from "./shell.js";
 
 describe("wrapInNixDevelop", () => {
 	it("wraps plain commands in nix develop", () => {
@@ -12,5 +14,20 @@ describe("wrapInNixDevelop", () => {
 		expect(wrapInNixDevelop("nix develop -c bash -lc 'pwd'")).toBe(
 			"nix develop -c bash -lc 'pwd'",
 		);
+	});
+});
+
+describe("ShellService read-only execution", () => {
+	it("prevents writes to repository files in run_ro_shell mode", async () => {
+		const repoDir = resolve(process.cwd());
+		const before = readFileSync(resolve(repoDir, "package.json"), "utf8");
+		const shell = new ShellService(repoDir, (command) => command);
+		const result = await shell.executeCommand(
+			"printf '\\n// should not be written\\n' >> package.json",
+			"read_only",
+		);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(readFileSync(resolve(repoDir, "package.json"), "utf8")).toBe(before);
 	});
 });

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,9 +1,20 @@
 import { exec } from "node:child_process";
+import {
+	chmodSync,
+	cpSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
 import { promisify } from "node:util";
 import type { AgentAction } from "./agent_protocol.js";
 import { logTrace, serializeError, textStats } from "./trace.js";
 
 const execAsync = promisify(exec);
+export type ShellExecutionMode = "read_only" | "read_write";
 
 export interface ShellResult {
 	stdout: string;
@@ -13,8 +24,24 @@ export interface ShellResult {
 }
 
 export class ShellService {
-	async executeCommand(command: string): Promise<ShellResult> {
-		const wrappedCommand = wrapInNixDevelop(command);
+	constructor(
+		private repoRoot: string = process.cwd(),
+		private commandWrapper: (command: string) => string = wrapInNixDevelop,
+	) {}
+
+	async executeCommand(
+		command: string,
+		executionMode: ShellExecutionMode = "read_write",
+	): Promise<ShellResult> {
+		if (executionMode === "read_only") {
+			return this.executeReadOnlyCommand(command);
+		}
+
+		return this.executeLiveCommand(command);
+	}
+
+	private async executeLiveCommand(command: string): Promise<ShellResult> {
+		const wrappedCommand = this.commandWrapper(command);
 		console.log(`Executing shell command: ${command}`);
 		const startedAt = Date.now();
 		logTrace("shell.command.begin", {
@@ -23,10 +50,13 @@ export class ShellService {
 			runsInsideNixDevelop: wrappedCommand !== command,
 		});
 		try {
-			const { stdout, stderr } = await execAsync(wrappedCommand);
+			const { stdout, stderr } = await execAsync(wrappedCommand, {
+				cwd: this.repoRoot,
+			});
 			logTrace("shell.command.success", {
 				command,
 				wrappedCommand,
+				executionMode: "read_write",
 				durationMs: Date.now() - startedAt,
 				stdout: textStats(stdout.trim()),
 				stderr: textStats(stderr.trim()),
@@ -42,6 +72,7 @@ export class ShellService {
 			logTrace("shell.command.error", {
 				command,
 				wrappedCommand,
+				executionMode: "read_write",
 				durationMs: Date.now() - startedAt,
 				exitCode: err.code || 1,
 				stdout: textStats(err.stdout?.trim() || ""),
@@ -57,6 +88,79 @@ export class ShellService {
 		}
 	}
 
+	private async executeReadOnlyCommand(command: string): Promise<ShellResult> {
+		const sandbox = createReadOnlySandbox(this.repoRoot);
+		const wrappedCommand = this.commandWrapper(command);
+		console.log(`Executing read-only shell command: ${command}`);
+		const startedAt = Date.now();
+		logTrace("shell.command.begin", {
+			command,
+			wrappedCommand,
+			executionMode: "read_only",
+			runsInsideNixDevelop: wrappedCommand !== command,
+			repoRoot: sandbox.repoDir,
+		});
+		try {
+			const { stdout, stderr } = await execAsync(wrappedCommand, {
+				cwd: sandbox.repoDir,
+				env: {
+					...process.env,
+					HOME: sandbox.homeDir,
+					TMPDIR: sandbox.tmpDir,
+					TMP: sandbox.tmpDir,
+					TEMP: sandbox.tmpDir,
+					GIT_OPTIONAL_LOCKS: "0",
+				},
+			});
+			logTrace("shell.command.success", {
+				command,
+				wrappedCommand,
+				executionMode: "read_only",
+				durationMs: Date.now() - startedAt,
+				stdout: textStats(stdout.trim()),
+				stderr: textStats(stderr.trim()),
+			});
+			return {
+				stdout: stdout.trim(),
+				stderr: stderr.trim(),
+				exitCode: 0,
+			};
+		} catch (error: unknown) {
+			const err = error as { stdout?: string; stderr?: string; code?: number };
+			console.error(`Read-only command execution failed: ${command}`, error);
+			logTrace("shell.command.error", {
+				command,
+				wrappedCommand,
+				executionMode: "read_only",
+				durationMs: Date.now() - startedAt,
+				exitCode: err.code || 1,
+				stdout: textStats(err.stdout?.trim() || ""),
+				stderr: textStats(err.stderr?.trim() || ""),
+				error: serializeError(error),
+			});
+			return {
+				stdout: err.stdout?.trim() || "",
+				stderr: err.stderr?.trim() || "",
+				exitCode: err.code || 1,
+				error: error instanceof Error ? error : new Error(String(error)),
+			};
+		} finally {
+			try {
+				rmSync(sandbox.rootDir, {
+					recursive: true,
+					force: true,
+					maxRetries: 5,
+					retryDelay: 50,
+				});
+			} catch (cleanupError) {
+				logTrace("shell.readOnlySandbox.cleanupError", {
+					repoRoot: sandbox.rootDir,
+					error: serializeError(cleanupError),
+				});
+			}
+		}
+	}
+
 	async executeActions(actions: AgentAction[]): Promise<string> {
 		let fullOutput = "";
 		logTrace("shell.actions.scan", {
@@ -64,18 +168,21 @@ export class ShellService {
 			actions: actions.map((action) => ({
 				type: action.type,
 				command:
-					action.type === "run_shell"
+					action.type === "run_shell" || action.type === "run_ro_shell"
 						? textStats(action.command)
 						: textStats("persist_work"),
 			})),
 		});
 
 		for (const action of actions) {
-			if (action.type !== "run_shell") {
+			if (action.type !== "run_shell" && action.type !== "run_ro_shell") {
 				continue;
 			}
 
-			const result = await this.executeCommand(action.command);
+			const result = await this.executeCommand(
+				action.command,
+				action.type === "run_ro_shell" ? "read_only" : "read_write",
+			);
 
 			fullOutput += `\n--- EXECUTING: ${action.command} ---\n`;
 			if (result.stdout) fullOutput += `STDOUT:\n${result.stdout}\n`;
@@ -98,4 +205,51 @@ export function wrapInNixDevelop(command: string): string {
 
 function shellSingleQuote(value: string): string {
 	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function createReadOnlySandbox(sourceRepoRoot: string): {
+	rootDir: string;
+	repoDir: string;
+	homeDir: string;
+	tmpDir: string;
+} {
+	const rootDir = join(
+		tmpdir(),
+		`overseer-ro-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+	);
+	const repoDir = join(rootDir, "repo");
+	const homeDir = join(rootDir, "home");
+	const tempDir = join(rootDir, "tmp");
+	mkdirSync(rootDir, { recursive: true });
+	mkdirSync(homeDir, { recursive: true });
+	mkdirSync(tempDir, { recursive: true });
+
+	cpSync(sourceRepoRoot, repoDir, { recursive: true });
+	makeDirectoryTreeReadOnly(repoDir);
+
+	return {
+		rootDir,
+		repoDir,
+		homeDir,
+		tmpDir: tempDir,
+	};
+}
+
+function makeDirectoryTreeReadOnly(path: string): void {
+	const stat = lstatSync(path);
+	if (stat.isSymbolicLink()) {
+		return;
+	}
+
+	if (stat.isDirectory()) {
+		if (basename(path) !== ".git") {
+			chmodSync(path, stat.mode & ~0o222);
+			for (const entry of readdirSync(path)) {
+				makeDirectoryTreeReadOnly(join(path, entry));
+			}
+		}
+		return;
+	}
+
+	chmodSync(path, stat.mode & ~0o222);
 }


### PR DESCRIPTION
## Summary
- add a read-only `run_ro_shell` action and restrict `run_shell` to read-write bots
- enforce shell capabilities in the runner and execute read-only commands in a disposable read-only repo copy
- ignore trace JSONL artifacts in git, update prompts/inspection output, and document the design in `SHELL_CAPABILITIES.md`

## Why
The current architecture relies on prompt text to keep review bots from editing the repo. This PR moves that distinction into manifest/runtime enforcement so Overseer and other read-only bots can inspect safely without being able to mutate the working tree.

## Validation
- `npm run lint` (existing warnings only in `src/index.ts` and `src/utils/github.ts`)
- `npm run build`
- `rm -rf dist && npm test`
