### PR TITLE
[codex] Stop status comments and limit retriggers

### DIFF
--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -21,7 +21,6 @@ Required top-level fields:
 Optional top-level fields:
 
 - `"final_response": "<required when task_status is done>"`
-- `"github_comment": "<markdown progress update to append to the issue thread>"`
 - `"handoff_to": "@planner"` or another explicit next recipient when a done response needs a structured handoff
 
 Rules:
@@ -32,7 +31,6 @@ Rules:
 {{AVAILABLE_ACTIONS_BULLETS}}
 {{SHELL_ACTION_RULES}}
 - If the task is complete, return `"task_status": "done"`, `"actions": []`, and a non-empty `final_response`.
-- `github_comment`, when present, is for in-progress status only. It is not a substitute for `final_response` and must not contain the final delegation.
 - `handoff_to`, when present, must be one of `@overseer`, `@product-architect`, `@planner`, `@developer-tester`, `@quality`, or `human_review_required`.
 - If you set `handoff_to`, the dispatcher will append the standardized `Next step: ...` line when it posts your final GitHub comment.
 - Do not use markdown fences or prose outside the JSON object.
@@ -50,8 +48,7 @@ Example in-progress response object:
   ],
   "next_step": "Read WORKFLOW.md and the referenced plan file before changing code.",
   "actions": {{IN_PROGRESS_EXAMPLE_ACTIONS}},
-  "task_status": "in_progress",
-  "github_comment": "Started work on the assigned task and am reading the required repository guidance first."
+  "task_status": "in_progress"
 }
 ```
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -57,25 +57,21 @@ async function run() {
 		productArchitect: new TaskPersona(
 			getBotOrThrow(botRegistry, "product-architect"),
 			gemini,
-			github,
 			persistence,
 		),
 		planner: new TaskPersona(
 			getBotOrThrow(botRegistry, "planner"),
 			gemini,
-			github,
 			persistence,
 		),
 		developerTester: new TaskPersona(
 			getBotOrThrow(botRegistry, "developer-tester"),
 			gemini,
-			github,
 			persistence,
 		),
 		quality: new TaskPersona(
 			getBotOrThrow(botRegistry, "quality"),
 			gemini,
-			github,
 			persistence,
 		),
 	};
@@ -400,6 +396,15 @@ async function finalizeRun(
 	// 1. Save Session Log as Artifact
 	const logPath = `session_${persona}_${Date.now()}.log`;
 	fs.writeFileSync(logPath, result.log);
+
+	if (result.suppressFinalComment) {
+		logTrace("dispatcher.finalize.commentSuppressed", {
+			persona,
+			reason: "iteration_result_requested_suppression",
+			log: textStats(result.log),
+		});
+		return;
+	}
 
 	// 2. Determine Next Persona
 	const nextPersona = resolveNextPersona(persona, result.handoffTo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,25 +26,21 @@ const personas = {
 	productArchitect: new TaskPersona(
 		getBotOrThrow(botRegistry, "product-architect"),
 		gemini,
-		github,
 		persistence,
 	),
 	planner: new TaskPersona(
 		getBotOrThrow(botRegistry, "planner"),
 		gemini,
-		github,
 		persistence,
 	),
 	developerTester: new TaskPersona(
 		getBotOrThrow(botRegistry, "developer-tester"),
 		gemini,
-		github,
 		persistence,
 	),
 	quality: new TaskPersona(
 		getBotOrThrow(botRegistry, "quality"),
 		gemini,
-		github,
 		persistence,
 	),
 };

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -8,7 +8,7 @@ import type {
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { GitHubService } from "../utils/github.js";
-import { getAttribution, isLimitReached } from "../utils/persona_helper.js";
+import { isLimitReached } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class OverseerPersona {
@@ -29,9 +29,9 @@ export class OverseerPersona {
 	}
 
 	private buildRunnerOptions(
-		owner: string,
-		repo: string,
-		issueNumber: number,
+		_owner: string,
+		_repo: string,
+		_issueNumber: number,
 	): AgentRunnerOptions {
 		return {
 			requireDoneHandoff: true,
@@ -42,10 +42,6 @@ export class OverseerPersona {
 				displayName: this.bot.displayName,
 				llm: this.bot.llm,
 				...summarizePromptAssembly(this.bot.prompt),
-			},
-			appendGithubComment: async (markdown: string) => {
-				const body = `${getAttribution(this.bot.displayName, issueNumber)}${markdown}`;
-				await this.github.addCommentToIssue(owner, repo, issueNumber, body);
 			},
 		};
 	}
@@ -70,7 +66,11 @@ export class OverseerPersona {
 				body,
 			)
 		) {
-			return { finalResponse: "", log: "Limit reached" };
+			return {
+				finalResponse: "",
+				log: "Limit reached",
+				suppressFinalComment: true,
+			};
 		}
 
 		const taskBody = `ISSUE TITLE: ${title}\n\nISSUE BODY:\n${body || "No body provided."}`;
@@ -115,7 +115,11 @@ export class OverseerPersona {
 				body,
 			)
 		) {
-			return { finalResponse: "", log: "Limit reached" };
+			return {
+				finalResponse: "",
+				log: "Limit reached",
+				suppressFinalComment: true,
+			};
 		}
 
 		const fullContext = await this.github.getFullIssueContext(

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -7,34 +7,29 @@ import type {
 } from "../utils/agent_runner.js";
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
-import type { GitHubService } from "../utils/github.js";
 import type { PersistenceService } from "../utils/persistence.js";
-import { getAttribution } from "../utils/persona_helper.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class TaskPersona {
 	private bot: LoadedBotDefinition;
 	private gemini: GeminiService;
-	private github: GitHubService;
 	private persistence: PersistenceService;
 	private runner: AgentRunner;
 
 	constructor(
 		bot: LoadedBotDefinition,
 		gemini: GeminiService,
-		github: GitHubService,
 		persistence: PersistenceService,
 	) {
 		this.bot = bot;
 		this.gemini = gemini;
-		this.github = github;
 		this.persistence = persistence;
 		this.runner = new AgentRunnerClass();
 	}
 
 	async handleTask(
-		owner: string,
-		repo: string,
+		_owner: string,
+		_repo: string,
 		issueNumber: number,
 		taskBody: string,
 	): Promise<IterationResult> {
@@ -67,10 +62,6 @@ export class TaskPersona {
 			persistWork: this.bot.allowPersistWork
 				? () => this.persistence.persistWork(issueNumber, this.bot.id)
 				: undefined,
-			appendGithubComment: async (markdown: string) => {
-				const body = `${getAttribution(this.bot.displayName, issueNumber)}${markdown}`;
-				await this.github.addCommentToIssue(owner, repo, issueNumber, body);
-			},
 		};
 
 		return this.runner.runAutonomousLoop(

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -64,7 +64,6 @@ Work to this workflow on every turn:
 - Return exactly one JSON object and nothing else.
 - Use \`"version": "${AGENT_PROTOCOL_VERSION}"\`.
 - Always include \`plan\`, \`next_step\`, \`actions\`, and \`task_status\`.
-- You may include \`github_comment\` as a concise markdown progress update to append to the GitHub issue thread.
 - You may include \`handoff_to\` on \`"done"\` responses to make the next recipient explicit. Valid values: ${AGENT_HANDOFF_TARGETS.map((target) => `\`${target}\``).join(", ")}.
 - If you need to inspect or modify the repository, respond with \`"task_status": "in_progress"\` and at least one action.
 - \`actions\` is an ordered list executed sequentially by the dispatcher.
@@ -72,13 +71,12 @@ Work to this workflow on every turn:
 - Use \`{"type":"run_ro_shell","command":"..."}\` for repository inspection and verification commands.
 - Use \`{"type":"run_shell","command":"..."}\` for repository file edits and verification commands when your persona is authorized to modify the live checkout.
 - Use \`{"type":"persist_work"}\` only when your persona is authorized to publish repo changes and you want the dispatcher-owned persistence mechanism to commit and push your work.
-- \`github_comment\` is for in-progress status only. Do not put delegation or the final handoff there.
 - If you set \`handoff_to\`, the dispatcher will append the standardized \`Next step: ...\` line when it posts your final GitHub comment.
 - If the task is complete, respond with \`"task_status": "done"\`, \`"actions": []\`, and \`final_response\` containing the concise human-facing summary that should be posted back to GitHub.
 - Do not use \`[RUN:command]\`, markdown fences, or prose outside the JSON object.
 
 Example in-progress response:
-{"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Read the relevant files before editing.","actions":[{"type":"run_ro_shell","command":"cd /project && ls -la"},{"type":"run_shell","command":"cd /project && cat WORKFLOW.md"}],"task_status":"in_progress","github_comment":"Started work and am inspecting the relevant files."}
+{"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Read the relevant files before editing.","actions":[{"type":"run_ro_shell","command":"cd /project && ls -la"},{"type":"run_shell","command":"cd /project && cat WORKFLOW.md"}],"task_status":"in_progress"}
 
 Example done response:
 {"version":"${AGENT_PROTOCOL_VERSION}","plan":["Inspect the relevant files.","Make the minimal required change.","Run targeted verification."],"next_step":"Return control to the dispatcher.","actions":[],"task_status":"done","handoff_to":"@planner","final_response":"Identified the relevant implementation touchpoints and prepared the planner handoff."}

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -163,7 +163,7 @@ describe("AgentRunner", () => {
 		expect(result.log).toContain('"commit_sha": "abc123"');
 	});
 
-	it("posts optional github_comment updates during the loop", async () => {
+	it("does not post github_comment status updates during the loop", async () => {
 		const responses = [
 			JSON.stringify({
 				version: AGENT_PROTOCOL_VERSION,
@@ -208,21 +208,11 @@ describe("AgentRunner", () => {
 			"System instruction",
 			"Initial message",
 			5,
-			{
-				appendGithubComment: async (markdown) => {
-					postedComments.push(markdown);
-				},
-			},
 		);
 
-		expect(postedComments).toEqual([
-			expect.stringContaining("<!-- overseer:status-update -->"),
-		]);
-		expect(postedComments[0]).toContain(
-			"Started work and am inspecting repository guidance.",
-		);
+		expect(postedComments).toEqual([]);
 		expect(result.finalResponse).toBe("Completed the requested work.");
-		expect(result.log).toContain("GITHUB COMMENT APPENDED");
+		expect(result.log).not.toContain("GITHUB COMMENT APPENDED");
 	});
 
 	it("rejects run_shell for read-only personas", async () => {

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -8,7 +8,6 @@ import {
 	type ParsedAgentProtocolResponse,
 	parseAgentProtocolResponse,
 } from "./agent_protocol.js";
-import { prependStatusUpdateSentinel } from "./comment_markers.js";
 import type { GeminiService } from "./gemini.js";
 import type { PersistWorkResult } from "./persistence.js";
 import type { ShellExecutionMode } from "./shell.js";
@@ -19,11 +18,11 @@ export interface IterationResult {
 	finalResponse: string;
 	handoffTo?: AgentHandoffTarget;
 	log: string;
+	suppressFinalComment?: boolean;
 }
 
 export interface AgentRunnerOptions {
 	persistWork?: () => Promise<PersistWorkResult>;
-	appendGithubComment?: (markdown: string) => Promise<void>;
 	requireDoneHandoff?: boolean;
 	modelName?: string;
 	shellAccess?: ShellExecutionMode;
@@ -141,14 +140,6 @@ export class AgentRunner {
 			});
 			this.log(`PROTOCOL RESPONSE: ${parsedResponse.rawJson}\n`);
 
-			if (parsedResponse.protocol.github_comment) {
-				await this.appendGithubComment(
-					parsedResponse.protocol.github_comment,
-					options,
-					iteration,
-				);
-			}
-
 			if (parsedResponse.protocol.task_status === "done") {
 				if (options.requireDoneHandoff && !parsedResponse.protocol.handoff_to) {
 					const error =
@@ -259,33 +250,6 @@ export class AgentRunner {
 		}
 
 		return outputs.join("\n");
-	}
-
-	private async appendGithubComment(
-		markdown: string,
-		options: AgentRunnerOptions,
-		iteration: number,
-	): Promise<void> {
-		if (!options.appendGithubComment) {
-			logTrace("agent.iteration.githubComment.skipped", {
-				iteration,
-				reason: "appendGithubComment not configured",
-				githubComment: textStats(markdown),
-				githubCommentRaw: markdown,
-			});
-			return;
-		}
-
-		const commentBody = prependStatusUpdateSentinel(markdown);
-		await options.appendGithubComment(commentBody);
-		logTrace("agent.iteration.githubComment.posted", {
-			iteration,
-			githubComment: textStats(markdown),
-			githubCommentRaw: markdown,
-			commentBody: textStats(commentBody),
-			commentBodyRaw: commentBody,
-		});
-		this.log(`GITHUB COMMENT APPENDED: ${markdown}\n`);
 	}
 
 	private loadRepositoryGuidance(): {

--- a/src/utils/persona_helper.test.ts
+++ b/src/utils/persona_helper.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { hasExplicitPersonaMention } from "./persona_helper.js";
+import { describe, expect, it, vi } from "vitest";
+import { hasExplicitPersonaMention, isLimitReached } from "./persona_helper.js";
 
 describe("hasExplicitPersonaMention", () => {
 	it("detects an explicit overseer mention in issue text", () => {
@@ -22,5 +22,48 @@ describe("hasExplicitPersonaMention", () => {
 				"@overseer",
 			),
 		).toBe(false);
+	});
+});
+
+describe("isLimitReached", () => {
+	it("returns true without posting a comment when the limit is reached", async () => {
+		const github = {
+			getIssueCommentCount: vi.fn().mockResolvedValue(100),
+			getIssue: vi.fn().mockResolvedValue({ data: { body: "" } }),
+			addCommentToIssue: vi.fn(),
+		};
+
+		await expect(
+			isLimitReached(
+				github as never,
+				"anicolao",
+				"overseer",
+				59,
+				"Overseer",
+				"@overseer",
+			),
+		).resolves.toBe(true);
+		expect(github.addCommentToIssue).not.toHaveBeenCalled();
+	});
+
+	it("still allows setlimit commands to update the limit", async () => {
+		const github = {
+			getIssueCommentCount: vi.fn().mockResolvedValue(100),
+			getIssue: vi.fn().mockResolvedValue({ data: { body: "" } }),
+			addCommentToIssue: vi.fn().mockResolvedValue(undefined),
+		};
+
+		await expect(
+			isLimitReached(
+				github as never,
+				"anicolao",
+				"overseer",
+				59,
+				"Overseer",
+				"@overseer",
+				"@overseer setlimit 250",
+			),
+		).resolves.toBe(false);
+		expect(github.addCommentToIssue).toHaveBeenCalledOnce();
 	});
 });

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -82,12 +82,6 @@ export async function isLimitReached(
 	const limit = limitMatch ? Number.parseInt(limitMatch[1], 10) : 100;
 
 	if (commentCount >= limit) {
-		await github.addCommentToIssue(
-			owner,
-			repo,
-			issueNumber,
-			`I am the ${personaName}. I have reached the safety limit of ${limit} comments on this issue. Please use \`${personaHandle} setlimit <number>\` to increase the limit if you wish for me to continue.`,
-		);
 		return true;
 	}
 


### PR DESCRIPTION
## Summary
- stop posting in-loop `github_comment` status updates to issue threads
- stop the Overseer from posting any final comment after the comment safety limit is reached
- update the protocol prompt/tests to match the quieter issue-comment behavior

## Why
Issue #59 showed that status updates were consuming a large share of the comment budget, and that once the Overseer hit its safety limit it could still finalize into another comment and retrigger the workflow.

## Validation
- `npm run build`
- `npm test`
- `npm run lint` (same two pre-existing warnings in `src/index.ts` and `src/utils/github.ts`)
