### PR TITLE
[codex] Trim continuation action output for agents

### DIFF
--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -214,4 +214,23 @@ I will comply.
 			'Continue the task using protocol "overseer/v1".',
 		);
 	});
+
+	it("truncates oversized action output in continuation messages", () => {
+		const longOutput = `STDOUT:\n${"x".repeat(12000)}`;
+		const message = buildContinuationMessage({
+			originalTask: "Planner Task:\nTask ID: issue-61",
+			previousResponseJson: JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Read files", "Write the plan"],
+				next_step: "Read files",
+				actions: [{ type: "run_ro_shell", command: "cat src/utils/foo.ts" }],
+				task_status: "in_progress",
+			}),
+			actionOutput: longOutput,
+		});
+
+		expect(message).toContain("LATEST ACTION OUTPUT:");
+		expect(message).toContain("[TRUNCATED");
+		expect(message.length).toBeLessThan(longOutput.length);
+	});
 });

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -1,3 +1,5 @@
+import { truncate } from "./text.js";
+
 export const AGENT_PROTOCOL_VERSION = "overseer/v1";
 export const AGENT_HANDOFF_TARGETS = [
 	"@overseer",
@@ -53,6 +55,8 @@ export interface ContinuationContext {
 	actionOutput: string;
 }
 
+const MAX_CONTINUATION_ACTION_OUTPUT_CHARS = 8000;
+
 export const AGENT_PROTOCOL_PROMPT = `
 RESPONSE PROTOCOL:
 Work to this workflow on every turn:
@@ -101,6 +105,11 @@ export function buildContinuationMessage({
 	previousGithubComment,
 	actionOutput,
 }: ContinuationContext): string {
+	const actionOutputForModel = truncate(
+		actionOutput,
+		MAX_CONTINUATION_ACTION_OUTPUT_CHARS,
+	);
+
 	return [
 		"ORIGINAL TASK:",
 		originalTask,
@@ -112,7 +121,7 @@ export function buildContinuationMessage({
 			? ["MOST RECENT GITHUB STATUS COMMENT:", previousGithubComment, ""]
 			: []),
 		"LATEST ACTION OUTPUT:",
-		actionOutput,
+		actionOutputForModel,
 		"",
 		"Continue the same task. Do not restart or reinterpret the assignment.",
 		"Use the original task and your most recent structured response to decide the next step.",


### PR DESCRIPTION
## Summary
- cap the amount of shell/action output that gets re-injected into the next LLM turn
- preserve the full output in traces/session logs while sending a compact continuation payload to the model
- add regression coverage for oversized continuation payloads

## Root cause
Issue #61 showed the Planner looping for 50 turns without ever writing its plan. The trace for run `23936409522` showed that iteration 2 was already about 6.3k tokens and iteration 4 about 8.9k tokens because `buildContinuationMessage()` was re-injecting massive raw file dumps on every turn. That newer behavior was the main regression versus earlier successful planner runs.

## Validation
- `npm run build`
- `npm test`
- `npm run lint` (same two pre-existing warnings in `src/index.ts` and `src/utils/github.ts`)
