### PR TITLE
[codex] Tighten agent focus and add run inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 *.log
 trace_*.jsonl
+.artifacts

--- a/bots.json
+++ b/bots.json
@@ -9,7 +9,8 @@
       "prompts/shared/github-actions.md",
       "prompts/shared/agent-protocol.md"
     ],
-    "max_iterations": 20
+    "max_iterations": 20,
+    "max_actions_per_turn": 2
   },
   "bots": [
     {
@@ -18,6 +19,8 @@
       "kind": "overseer",
       "shell_access": "read_only",
       "allow_persist_work": false,
+      "max_iterations": 12,
+      "max_actions_per_turn": 2,
       "prompt_files": [
         "prompts/shared/overseer-core.md",
         "prompts/overseer.md"
@@ -29,6 +32,8 @@
       "kind": "task",
       "shell_access": "read_write",
       "allow_persist_work": true,
+      "max_iterations": 10,
+      "max_actions_per_turn": 1,
       "prompt_files": [
         "prompts/shared/task-agent.md",
         "prompts/shared/persisting-agent.md",
@@ -41,6 +46,8 @@
       "kind": "task",
       "shell_access": "read_write",
       "allow_persist_work": true,
+      "max_iterations": 10,
+      "max_actions_per_turn": 1,
       "prompt_files": [
         "prompts/shared/task-agent.md",
         "prompts/shared/persisting-agent.md",
@@ -53,6 +60,8 @@
       "kind": "task",
       "shell_access": "read_write",
       "allow_persist_work": true,
+      "max_iterations": 12,
+      "max_actions_per_turn": 1,
       "prompt_files": [
         "prompts/shared/task-agent.md",
         "prompts/shared/persisting-agent.md",
@@ -66,6 +75,8 @@
       "kind": "task",
       "shell_access": "read_only",
       "allow_persist_work": false,
+      "max_iterations": 8,
+      "max_actions_per_turn": 1,
       "prompt_files": [
         "prompts/shared/task-agent.md",
         "prompts/shared/read-only-agent.md",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "prepare": "husky",
     "lint": "biome check src/",
     "format": "biome format --write src/",
-    "bots:inspect": "tsx src/scripts/inspect_bots.ts"
+    "bots:inspect": "tsx src/scripts/inspect_bots.ts",
+    "runs:inspect": "tsx src/scripts/inspect_run.ts"
   },
   "repository": {
     "type": "git",

--- a/prompts/developer-tester.md
+++ b/prompts/developer-tester.md
@@ -2,9 +2,20 @@ You implement code and verification for the assigned task.
 
 Use a plan-act-verify cycle:
 
-- understand the task packet
-- inspect only the files needed to execute it
-- make the implementation change
-- run the smallest useful verification commands
+- understand the task packet before touching the repository
+- read the named plan file and files-to-read first
+- inspect only the files needed to execute the task summary
+- make the smallest implementation change that satisfies `Done When`
+- run the smallest useful verification commands from the task packet
+- persist the work
+- verify the persisted branch state before finishing
+
+Developer/Tester guardrails:
+
+- default to exactly one action per turn
+- do not spend multiple turns re-listing directories or rereading the same file without a reason
+- do not rerun the same failing test or persistence step unless you changed code, commands, or environment
+- if the task packet is missing required detail, say so explicitly in the final summary instead of inventing scope
+- if the requested files or plan do not exist, verify that once and then stop with a blocker rather than searching the whole repo repeatedly
 
 Your final response should summarize the changes you implemented and the verification results.

--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -10,7 +10,18 @@ When assigning work to `@developer-tester`, include a structured handoff block i
 Developer Task:
 Task ID: <task identifier or "none">
 Plan File: <repo path or "none">
-Files To Read: <comma-separated repo paths or "none">
+Files To Read:
+- <repo path>
 Task Summary: <single actionable sentence>
+Done When: <single sentence describing the observable completion condition>
+Verification:
+- <repo command>
+
+Requirements for Overseer handoffs:
+
+- every developer task must define `Done When`
+- include at least one targeted verification command whenever you can
+- list only the files the worker actually needs first; avoid broad repo scavenger hunts
+- if the latest responder claims a file changed, inspect that file before delegating follow-up work
 
 Keep your final summary to at most three sentences before the required delegation suffix.

--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -30,10 +30,13 @@ Rules:
 - Available action types:
 {{AVAILABLE_ACTIONS_BULLETS}}
 {{SHELL_ACTION_RULES}}
+- Action-count rules:
+{{ACTION_COUNT_RULES}}
 - If the task is complete, return `"task_status": "done"`, `"actions": []`, and a non-empty `final_response`.
 - `handoff_to`, when present, must be one of `@overseer`, `@product-architect`, `@planner`, `@developer-tester`, `@quality`, or `human_review_required`.
 - If you set `handoff_to`, the dispatcher will append the standardized `Next step: ...` line when it posts your final GitHub comment.
 - Do not use markdown fences or prose outside the JSON object.
+- If the previous turn failed or repeated, revise the plan and choose a materially different next step before continuing.
 
 Example in-progress response object:
 

--- a/prompts/shared/persisting-agent.md
+++ b/prompts/shared/persisting-agent.md
@@ -6,6 +6,11 @@ When your work is ready, call `{"type":"persist_work"}`.
 
 Do not run `git commit` or `git push` yourself.
 
-If persistence fails, inspect the reported error, fix what you can in the repository, and try again until it succeeds.
+If persistence fails, inspect the reported error, change something material, and then try again. Do not retry the same failing persistence step without a new fix.
 
-You are not done when a local file exists. You are done only after persistence succeeds and you verify with read-only git commands that `origin/bot/issue-<n>` contains the intended change.
+Completion requirements after any successful `run_shell` action:
+
+- you are not done when a local file exists
+- you are not done when local tests pass
+- you are done only after `persist_work` succeeds
+- after persistence, run at least one `run_ro_shell` verification command that inspects `origin/bot/issue-<n>` or the persisted file contents before concluding

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -2,8 +2,21 @@ You are a task-execution bot. Your job is to receive a task and execute it in th
 
 The dynamic task input is the canonical assignment. Do not wait for a second hidden instruction layer from the dispatcher.
 
-If the task references files to read first, read those files before broader exploration.
+Treat the task packet as binding:
+
+- read the explicitly named files before broader exploration
+- use the `Task Summary` as the implementation goal
+- use `Done When` as the completion bar
+- use `Verification` as the default verification checklist unless the repository proves a command is invalid
 
 Use the JSON action protocol to inspect the repository, verify results, and make changes only when your available actions permit it.
+
+Execution discipline:
+
+- write a short concrete plan on the first turn and revise it only when the evidence changes
+- keep the next step narrowly scoped to one immediate action
+- after at most two inspection turns, either start editing, run verification, or explain the blocker
+- if a command fails, change the approach or the repository state before retrying
+- if you are blocked after two materially different attempts, stop looping and return control with a concise blocker summary
 
 Do not delegate. Complete the task you were given and return control to the dispatcher.

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -9,6 +9,7 @@ describe("bot_config", () => {
 		expect(developer.kind).toBe("task");
 		expect(developer.shellAccess).toBe("read_write");
 		expect(developer.allowPersistWork).toBe(true);
+		expect(developer.maxActionsPerTurn).toBe(1);
 		expect(developer.prompt.promptFiles).toContain(
 			"prompts/shared/agent-protocol.md",
 		);
@@ -24,6 +25,9 @@ describe("bot_config", () => {
 		expect(developer.prompt.concatenatedPrompt).toContain(
 			'"type":"run_ro_shell"',
 		);
+		expect(developer.prompt.concatenatedPrompt).toContain(
+			"You may return at most 1 action in a single response.",
+		);
 		expect(developer.prompt.concatenatedPrompt).toContain('"type":"run_shell"');
 		expect(developer.prompt.concatenatedPrompt).not.toContain(
 			"BEGIN PROMPT FILE:",
@@ -36,6 +40,7 @@ describe("bot_config", () => {
 		expect(getBotOrThrow(registry, "overseer").kind).toBe("overseer");
 		expect(getBotOrThrow(registry, "quality").shellAccess).toBe("read_only");
 		expect(getBotOrThrow(registry, "quality").allowPersistWork).toBe(false);
+		expect(getBotOrThrow(registry, "overseer").maxActionsPerTurn).toBe(2);
 		expect(
 			getBotOrThrow(registry, "quality").prompt.concatenatedPrompt,
 		).toContain("- `run_shell` is unavailable to this bot.");

--- a/src/bots/bot_config.ts
+++ b/src/bots/bot_config.ts
@@ -15,6 +15,7 @@ interface RawBotManifest {
 		};
 		prompt_files?: string[];
 		max_iterations?: number;
+		max_actions_per_turn?: number;
 	};
 	bots?: RawBotDefinition[];
 }
@@ -31,6 +32,7 @@ interface RawBotDefinition {
 	prompt_files?: string[];
 	allow_persist_work?: boolean;
 	max_iterations?: number;
+	max_actions_per_turn?: number;
 }
 
 export interface LoadedPromptAssembly {
@@ -50,6 +52,7 @@ export interface LoadedBotDefinition {
 	shellAccess: ShellAccess;
 	allowPersistWork: boolean;
 	maxIterations: number;
+	maxActionsPerTurn: number;
 	prompt: LoadedPromptAssembly;
 }
 
@@ -77,6 +80,7 @@ export function loadBotRegistry(
 	const defaultProvider = defaults.llm?.provider;
 	const defaultModel = defaults.llm?.model;
 	const defaultMaxIterations = defaults.max_iterations ?? 50;
+	const defaultMaxActionsPerTurn = defaults.max_actions_per_turn ?? 1;
 
 	const all = rawManifest.bots.map((rawBot) =>
 		loadBotDefinition(repoRoot, rawBot, {
@@ -84,6 +88,7 @@ export function loadBotRegistry(
 			defaultProvider,
 			defaultModel,
 			defaultMaxIterations,
+			defaultMaxActionsPerTurn,
 		}),
 	);
 
@@ -119,6 +124,7 @@ function loadBotDefinition(
 		defaultProvider?: string;
 		defaultModel?: string;
 		defaultMaxIterations: number;
+		defaultMaxActionsPerTurn: number;
 	},
 ): LoadedBotDefinition {
 	const id = requireNonEmptyString(rawBot.id, "bot.id");
@@ -141,6 +147,10 @@ function loadBotDefinition(
 		rawBot.max_iterations ?? defaults.defaultMaxIterations,
 		`${id}.max_iterations`,
 	);
+	const maxActionsPerTurn = parsePositiveInteger(
+		rawBot.max_actions_per_turn ?? defaults.defaultMaxActionsPerTurn,
+		`${id}.max_actions_per_turn`,
+	);
 	const promptFiles = [
 		...defaults.defaultPromptFiles,
 		...(rawBot.prompt_files || []),
@@ -160,9 +170,11 @@ function loadBotDefinition(
 		shellAccess,
 		allowPersistWork,
 		maxIterations,
+		maxActionsPerTurn,
 		prompt: loadPromptAssembly(repoRoot, promptFiles, {
 			shellAccess,
 			allowPersistWork,
+			maxActionsPerTurn,
 		}),
 	};
 }
@@ -173,6 +185,7 @@ function loadPromptAssembly(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		maxActionsPerTurn: number;
 	},
 ): LoadedPromptAssembly {
 	const duplicatePromptFiles = findDuplicates(promptFiles);
@@ -205,6 +218,7 @@ function renderPromptTemplate(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		maxActionsPerTurn: number;
 	},
 ): string {
 	return content
@@ -217,7 +231,12 @@ function renderPromptTemplate(
 			"{{IN_PROGRESS_EXAMPLE_ACTIONS}}",
 			buildExampleActionsJson(context),
 		)
-		.replaceAll("{{SHELL_ACTION_RULES}}", buildShellActionRules(context));
+		.replaceAll("{{SHELL_ACTION_RULES}}", buildShellActionRules(context))
+		.replaceAll("{{MAX_ACTIONS_PER_TURN}}", String(context.maxActionsPerTurn))
+		.replaceAll(
+			"{{ACTION_COUNT_RULES}}",
+			buildActionCountRules(context.maxActionsPerTurn),
+		);
 }
 
 function parseKind(value: string | undefined, fieldPrefix: string): BotKind {
@@ -312,31 +331,32 @@ function buildAvailableActionsBullets(context: {
 function buildExampleActionsJson(context: {
 	shellAccess: ShellAccess;
 	allowPersistWork: boolean;
+	maxActionsPerTurn: number;
 }): string {
 	const actions =
 		context.shellAccess === "read_write"
-			? `[
-    {
-      "type": "run_ro_shell",
-      "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
-    },
-    {
-      "type": "run_shell",
-      "command": "cat docs/plans/current-plan.md"
-    }
-  ]`
-			: `[
-    {
-      "type": "run_ro_shell",
-      "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
-    },
-    {
-      "type": "run_ro_shell",
-      "command": "cat docs/plans/current-plan.md"
-    }
-  ]`;
+			? [
+					{
+						type: "run_ro_shell",
+						command: "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true",
+					},
+					{
+						type: "run_shell",
+						command: "cat docs/plans/current-plan.md",
+					},
+				]
+			: [
+					{
+						type: "run_ro_shell",
+						command: "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true",
+					},
+					{
+						type: "run_ro_shell",
+						command: "cat docs/plans/current-plan.md",
+					},
+				];
 
-	return actions;
+	return JSON.stringify(actions.slice(0, context.maxActionsPerTurn), null, 2);
 }
 
 function buildShellActionRules(context: {
@@ -355,6 +375,15 @@ function buildShellActionRules(context: {
 		"- Use `run_ro_shell` for inspection and verification only.",
 		"- `run_shell` is unavailable to this bot.",
 		"- If the environment is missing a tool you need, note that in your output instead of trying to modify the repository or tooling configuration yourself.",
+	].join("\n");
+}
+
+function buildActionCountRules(maxActionsPerTurn: number): string {
+	const actionWord = maxActionsPerTurn === 1 ? "action" : "actions";
+	return [
+		`- You may return at most ${maxActionsPerTurn} ${actionWord} in a single response.`,
+		"- Prefer exactly one action per turn unless bundling is clearly necessary to complete one immediate step.",
+		"- Do not repeat the same action on consecutive turns unless the repository state changed or your previous output explains why the retry is materially different.",
 	].join("\n");
 }
 

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -35,8 +35,10 @@ export class OverseerPersona {
 	): AgentRunnerOptions {
 		return {
 			requireDoneHandoff: true,
+			loopAbortHandoffTo: "human_review_required",
 			modelName: this.bot.llm.model,
 			shellAccess: this.bot.shellAccess,
+			maxActionsPerTurn: this.bot.maxActionsPerTurn,
 			promptDefinition: {
 				botId: this.bot.id,
 				displayName: this.bot.displayName,

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -8,6 +8,10 @@ import type {
 import { AgentRunner as AgentRunnerClass } from "../utils/agent_runner.js";
 import type { GeminiService } from "../utils/gemini.js";
 import type { PersistenceService } from "../utils/persistence.js";
+import {
+	parseTaskPacket,
+	renderTaskPacketForPrompt,
+} from "../utils/task_packet.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
 export class TaskPersona {
@@ -36,6 +40,8 @@ export class TaskPersona {
 		console.log(
 			`${this.bot.displayName} handling task for issue #${issueNumber}`,
 		);
+		const taskPacket = parseTaskPacket(taskBody);
+		const canonicalTaskBody = renderTaskPacketForPrompt(taskPacket);
 
 		logTrace("persona.task.promptPrepared", {
 			botId: this.bot.id,
@@ -43,9 +49,13 @@ export class TaskPersona {
 			issueNumber,
 			taskBody: textStats(taskBody),
 			taskBodyRaw: taskBody,
+			taskPacket,
+			canonicalTaskBody: textStats(canonicalTaskBody),
+			canonicalTaskBodyRaw: canonicalTaskBody,
 			shellAccess: this.bot.shellAccess,
 			allowPersistWork: this.bot.allowPersistWork,
 			maxIterations: this.bot.maxIterations,
+			maxActionsPerTurn: this.bot.maxActionsPerTurn,
 			llm: this.bot.llm,
 			prompt: summarizePromptAssembly(this.bot.prompt),
 		});
@@ -53,6 +63,7 @@ export class TaskPersona {
 		const runnerOptions: AgentRunnerOptions = {
 			modelName: this.bot.llm.model,
 			shellAccess: this.bot.shellAccess,
+			maxActionsPerTurn: this.bot.maxActionsPerTurn,
 			promptDefinition: {
 				botId: this.bot.id,
 				displayName: this.bot.displayName,
@@ -67,7 +78,7 @@ export class TaskPersona {
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			this.bot.prompt.concatenatedPrompt,
-			taskBody,
+			canonicalTaskBody,
 			this.bot.maxIterations,
 			runnerOptions,
 		);

--- a/src/scripts/inspect_bots.test.ts
+++ b/src/scripts/inspect_bots.test.ts
@@ -25,6 +25,7 @@ describe("inspect_bots", () => {
 
 		expect(markdown).toContain("# Developer/Tester");
 		expect(markdown).toContain("Shell Access: `read_write`");
+		expect(markdown).toContain("Max Actions Per Turn: 1");
 		expect(markdown).toContain("## Prompt Files");
 		expect(markdown).toContain("`prompts/shared/developer-guidance.md`");
 		expect(markdown).toContain("## Concatenated Prompt");

--- a/src/scripts/inspect_bots.ts
+++ b/src/scripts/inspect_bots.ts
@@ -66,6 +66,7 @@ export function renderBotDetailMarkdown(bot: LoadedBotDefinition): string {
 		`- Model: \`${bot.llm.model}\``,
 		`- Persist Work: ${bot.allowPersistWork ? "yes" : "no"}`,
 		`- Max Iterations: ${bot.maxIterations}`,
+		`- Max Actions Per Turn: ${bot.maxActionsPerTurn}`,
 		"",
 		"## Prompt Files",
 		"",

--- a/src/scripts/inspect_run.test.ts
+++ b/src/scripts/inspect_run.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildTraceSummaries,
+	parseArgs,
+	renderMarkdownReport,
+} from "./inspect_run.js";
+
+describe("inspect_run", () => {
+	it("parses CLI arguments with defaults", () => {
+		const parsed = parseArgs(["12345", "--skip-download"]);
+
+		expect(parsed.runId).toBe("12345");
+		expect(parsed.skipDownload).toBe(true);
+		expect(parsed.artifactsDir).toContain(".artifacts/run-12345");
+	});
+
+	it("summarizes trace events into persona flows", () => {
+		const summaries = buildTraceSummaries(
+			[
+				{
+					traceId: "trace-1",
+					persona: "developer-tester",
+					owner: "anicolao",
+					repo: "overseer",
+					issueNumber: 42,
+					eventName: "issue_comment",
+					sender: "alice",
+					event: "agent.iteration.protocol",
+					iteration: 1,
+					nextStep: "Read the plan file.",
+					taskStatus: "in_progress",
+					actionTypes: ["run_ro_shell"],
+				},
+				{
+					traceId: "trace-1",
+					persona: "developer-tester",
+					event: "dispatcher.finalize.begin",
+				},
+			],
+			["/tmp/session_developer-tester_1.log"],
+		);
+
+		expect(summaries).toHaveLength(1);
+		expect(summaries[0]?.outcome).toBe("finalized");
+		expect(summaries[0]?.sessionLogPath).toContain("session_developer-tester");
+		expect(summaries[0]?.keyEvents[0]).toContain("iteration 1");
+	});
+
+	it("renders a markdown report with persona and backstop sections", () => {
+		const markdown = renderMarkdownReport({
+			runId: "12345",
+			artifactsDir: "/tmp/run-12345",
+			files: ["/tmp/run-12345/trace_12345.jsonl"],
+			traceSummaries: [
+				{
+					traceId: "trace-1",
+					persona: "planner",
+					owner: "anicolao",
+					repo: "overseer",
+					issueNumber: 9,
+					eventName: "issues",
+					sender: "alice",
+					iterationCount: 2,
+					outcome: "finalized",
+					keyEvents: [
+						"iteration 1 | status=in_progress | next=Inspect docs | actions=run_ro_shell",
+					],
+					sessionLogPath: "/tmp/run-12345/session_planner_1.log",
+				},
+			],
+			persistenceBackstop: {
+				metadataPath: "/tmp/run-12345/metadata.json",
+				metadata: {
+					issue_number: 9,
+					target_branch: "bot/issue-9",
+				},
+			},
+		});
+
+		expect(markdown).toContain("# Run 12345 Inspection");
+		expect(markdown).toContain("## Persona Flows");
+		expect(markdown).toContain("### planner");
+		expect(markdown).toContain("## Persistence Backstop");
+		expect(markdown).toContain("## Artifact Inventory");
+	});
+});

--- a/src/scripts/inspect_run.ts
+++ b/src/scripts/inspect_run.ts
@@ -1,0 +1,430 @@
+import { execFileSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface CliOptions {
+	runId: string;
+	artifactsDir: string;
+	outputPath?: string;
+	skipDownload: boolean;
+}
+
+interface TraceEventRecord {
+	ts?: string;
+	event?: string;
+	traceId?: string;
+	persona?: string;
+	owner?: string;
+	repo?: string;
+	issueNumber?: number;
+	eventName?: string;
+	sender?: string;
+	iteration?: number;
+	nextStep?: string;
+	taskStatus?: string;
+	actionTypes?: string[];
+	error?: string;
+	finalResponse?: {
+		preview?: string;
+	};
+	log?: {
+		preview?: string;
+	};
+}
+
+interface TraceSummary {
+	traceId: string;
+	persona: string;
+	owner?: string;
+	repo?: string;
+	issueNumber?: number;
+	eventName?: string;
+	sender?: string;
+	iterationCount: number;
+	outcome: string;
+	keyEvents: string[];
+	sessionLogPath?: string;
+}
+
+interface PersistenceBackstopSummary {
+	metadataPath: string;
+	commentPath?: string;
+	changedPathsPath?: string;
+	metadata: Record<string, unknown>;
+}
+
+export function parseArgs(args: string[]): CliOptions {
+	let runId = "";
+	let artifactsDir = "";
+	let outputPath: string | undefined;
+	let skipDownload = false;
+
+	for (let index = 0; index < args.length; index++) {
+		const arg = args[index];
+		if (!arg) {
+			continue;
+		}
+		if (arg === "--artifacts-dir") {
+			artifactsDir = requireValue(args[++index], "--artifacts-dir");
+			continue;
+		}
+		if (arg === "--out") {
+			outputPath = requireValue(args[++index], "--out");
+			continue;
+		}
+		if (arg === "--skip-download") {
+			skipDownload = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h") {
+			printUsageAndExit(0);
+		}
+		if (arg.startsWith("--")) {
+			throw new Error(`Unknown option: ${arg}`);
+		}
+		if (!runId) {
+			runId = arg;
+			continue;
+		}
+		throw new Error(`Unexpected positional argument: ${arg}`);
+	}
+
+	if (!runId) {
+		throw new Error(
+			"Usage: npm run runs:inspect -- <run-id> [--artifacts-dir DIR] [--out FILE] [--skip-download]",
+		);
+	}
+
+	const resolvedArtifactsDir = resolve(
+		artifactsDir || `.artifacts/run-${runId}`,
+	);
+	return {
+		runId,
+		artifactsDir: resolvedArtifactsDir,
+		outputPath: outputPath ? resolve(outputPath) : undefined,
+		skipDownload,
+	};
+}
+
+function requireValue(value: string | undefined, flag: string): string {
+	if (!value) {
+		throw new Error(`Expected a value after ${flag}`);
+	}
+	return value;
+}
+
+function printUsageAndExit(exitCode: number): never {
+	process.stdout.write(
+		[
+			"# inspect_run",
+			"",
+			"Download GitHub Actions artifacts for a run and build a markdown inspection report.",
+			"",
+			"## Usage",
+			"",
+			"- `npm run runs:inspect -- <run-id>`",
+			"- `npm run runs:inspect -- <run-id> --skip-download`",
+			"- `npm run runs:inspect -- <run-id> --artifacts-dir .artifacts/custom --out run.md`",
+			"",
+		].join("\n"),
+	);
+	process.exit(exitCode);
+}
+
+function ensureGhAvailable(): void {
+	try {
+		execFileSync("gh", ["--version"], { stdio: "ignore" });
+	} catch (error) {
+		throw new Error(
+			`GitHub CLI \`gh\` is required for artifact download: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+}
+
+function downloadArtifacts(runId: string, artifactsDir: string): void {
+	ensureGhAvailable();
+	mkdirSync(artifactsDir, { recursive: true });
+	execFileSync("gh", ["run", "download", runId, "--dir", artifactsDir], {
+		stdio: "inherit",
+	});
+}
+
+function listFilesRecursive(rootDir: string): string[] {
+	if (!existsSync(rootDir)) {
+		return [];
+	}
+
+	const results: string[] = [];
+	for (const entry of readdirSync(rootDir)) {
+		const fullPath = resolve(rootDir, entry);
+		const stat = statSync(fullPath);
+		if (stat.isDirectory()) {
+			results.push(...listFilesRecursive(fullPath));
+			continue;
+		}
+		results.push(fullPath);
+	}
+	return results.sort();
+}
+
+function readTraceEvents(files: string[]): TraceEventRecord[] {
+	const traceFiles = files.filter((file) => /trace_.*\.jsonl$/.test(file));
+	const events: TraceEventRecord[] = [];
+	for (const traceFile of traceFiles) {
+		const lines = readFileSync(traceFile, "utf8")
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter(Boolean);
+		for (const line of lines) {
+			try {
+				events.push(JSON.parse(line) as TraceEventRecord);
+			} catch (error) {
+				console.warn(
+					`Skipping invalid JSONL line in ${traceFile}: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
+			}
+		}
+	}
+	return events;
+}
+
+export function buildTraceSummaries(
+	events: TraceEventRecord[],
+	files: string[],
+): TraceSummary[] {
+	const grouped = new Map<string, TraceEventRecord[]>();
+	for (const event of events) {
+		if (!event.traceId) {
+			continue;
+		}
+		const existing = grouped.get(event.traceId) || [];
+		existing.push(event);
+		grouped.set(event.traceId, existing);
+	}
+
+	return Array.from(grouped.entries())
+		.map(([traceId, traceEvents]) => {
+			const first = traceEvents[0];
+			const iterationEvents = traceEvents.filter(
+				(event) => event.event === "agent.iteration.protocol",
+			);
+			const protocolErrors = traceEvents
+				.filter((event) => event.event === "agent.iteration.protocolError")
+				.map((event) => event.error)
+				.filter((value): value is string => Boolean(value));
+			const finalized = traceEvents.find(
+				(event) => event.event === "dispatcher.finalize.begin",
+			);
+			const loopAbort = traceEvents.find(
+				(event) => event.event === "agent.loop.abortedForRepeatedCycles",
+			);
+			const maxedOut = traceEvents.find(
+				(event) => event.event === "agent.loop.maxIterationsReached",
+			);
+			const sessionLogPath = findMatchingSessionLog(files, first?.persona);
+			const keyEvents = iterationEvents.map((event) => {
+				const pieces = [
+					event.iteration ? `iteration ${event.iteration}` : undefined,
+					event.taskStatus ? `status=${event.taskStatus}` : undefined,
+					event.nextStep ? `next=${event.nextStep}` : undefined,
+					event.actionTypes?.length
+						? `actions=${event.actionTypes.join(",")}`
+						: "actions=none",
+				].filter(Boolean);
+				return pieces.join(" | ");
+			});
+
+			for (const error of protocolErrors) {
+				keyEvents.push(`protocol-error | ${error}`);
+			}
+
+			let outcome = "incomplete";
+			if (loopAbort) {
+				outcome = "aborted-for-loop";
+			} else if (maxedOut) {
+				outcome = "max-iterations";
+			} else if (finalized) {
+				outcome = "finalized";
+			}
+
+			return {
+				traceId,
+				persona: first?.persona || "unknown",
+				owner: first?.owner,
+				repo: first?.repo,
+				issueNumber: first?.issueNumber,
+				eventName: first?.eventName,
+				sender: first?.sender,
+				iterationCount: iterationEvents.length,
+				outcome,
+				keyEvents,
+				sessionLogPath,
+			};
+		})
+		.sort((left, right) => left.traceId.localeCompare(right.traceId));
+}
+
+function findMatchingSessionLog(
+	files: string[],
+	persona?: string,
+): string | undefined {
+	if (!persona) {
+		return undefined;
+	}
+	const normalizedPersona = persona.replaceAll("/", "-");
+	return files.find(
+		(file) =>
+			file.includes(`session_${normalizedPersona}_`) && file.endsWith(".log"),
+	);
+}
+
+function readPersistenceBackstop(
+	files: string[],
+): PersistenceBackstopSummary | undefined {
+	const metadataPath = files.find((file) => file.endsWith("metadata.json"));
+	if (!metadataPath) {
+		return undefined;
+	}
+
+	const metadata = JSON.parse(readFileSync(metadataPath, "utf8")) as Record<
+		string,
+		unknown
+	>;
+	return {
+		metadataPath,
+		commentPath: files.find((file) => file.endsWith("comment.md")),
+		changedPathsPath: files.find((file) => file.endsWith("changed-paths.txt")),
+		metadata,
+	};
+}
+
+export function renderMarkdownReport(input: {
+	runId: string;
+	artifactsDir: string;
+	files: string[];
+	traceSummaries: TraceSummary[];
+	persistenceBackstop?: PersistenceBackstopSummary;
+}): string {
+	const lines: string[] = [
+		`# Run ${input.runId} Inspection`,
+		"",
+		`- Artifacts directory: \`${input.artifactsDir}\``,
+		`- Files discovered: \`${input.files.length}\``,
+		`- Trace flows: \`${input.traceSummaries.length}\``,
+		`- Persistence backstop artifact: \`${input.persistenceBackstop ? "present" : "absent"}\``,
+		"",
+	];
+
+	if (input.traceSummaries.length > 0) {
+		lines.push("## Persona Flows", "");
+		for (const summary of input.traceSummaries) {
+			lines.push(`### ${summary.persona}`, "");
+			lines.push(
+				`- Trace ID: \`${summary.traceId}\``,
+				`- Repository: \`${summary.owner || "unknown"}/${summary.repo || "unknown"}\``,
+				`- Issue: \`${summary.issueNumber ?? "unknown"}\``,
+				`- Event: \`${summary.eventName || "unknown"}\``,
+				`- Sender: \`${summary.sender || "unknown"}\``,
+				`- Iterations observed: \`${summary.iterationCount}\``,
+				`- Outcome: \`${summary.outcome}\``,
+			);
+			if (summary.sessionLogPath) {
+				lines.push(`- Session log: \`${summary.sessionLogPath}\``);
+			}
+			lines.push("", "#### Key Events", "");
+			if (summary.keyEvents.length === 0) {
+				lines.push("- No iteration protocol events were found.", "");
+			} else {
+				for (const event of summary.keyEvents) {
+					lines.push(`- ${event}`);
+				}
+				lines.push("");
+			}
+		}
+	}
+
+	if (input.persistenceBackstop) {
+		lines.push("## Persistence Backstop", "");
+		for (const [key, value] of Object.entries(
+			input.persistenceBackstop.metadata,
+		)) {
+			lines.push(`- ${key}: \`${String(value)}\``);
+		}
+		if (input.persistenceBackstop.commentPath) {
+			lines.push(
+				`- Comment file: \`${input.persistenceBackstop.commentPath}\``,
+			);
+		}
+		if (input.persistenceBackstop.changedPathsPath) {
+			lines.push(
+				`- Changed paths file: \`${input.persistenceBackstop.changedPathsPath}\``,
+			);
+		}
+		lines.push("");
+	}
+
+	lines.push("## Artifact Inventory", "");
+	for (const file of input.files) {
+		lines.push(`- \`${file}\``);
+	}
+	lines.push("");
+
+	return `${lines.join("\n")}\n`;
+}
+
+function main(): void {
+	const options = parseArgs(process.argv.slice(2));
+	if (!options.skipDownload) {
+		downloadArtifacts(options.runId, options.artifactsDir);
+	}
+
+	const files = listFilesRecursive(options.artifactsDir);
+	if (files.length === 0) {
+		throw new Error(
+			`No artifact files were found in ${options.artifactsDir}. Run without --skip-download or check the run id.`,
+		);
+	}
+
+	const traceEvents = readTraceEvents(files);
+	const traceSummaries = buildTraceSummaries(traceEvents, files);
+	const persistenceBackstop = readPersistenceBackstop(files);
+	const outputPath =
+		options.outputPath ||
+		resolve(options.artifactsDir, `run-${options.runId}.md`);
+	const markdown = renderMarkdownReport({
+		runId: options.runId,
+		artifactsDir: options.artifactsDir,
+		files,
+		traceSummaries,
+		persistenceBackstop,
+	});
+
+	writeFileSync(outputPath, markdown, "utf8");
+	process.stdout.write(`${outputPath}\n`);
+}
+
+const isMainModule =
+	process.argv[1] !== undefined &&
+	fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMainModule) {
+	try {
+		main();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(message);
+		process.exit(1);
+	}
+}

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -52,6 +52,7 @@ export interface ContinuationContext {
 	previousResponseJson: string;
 	previousGithubComment?: string;
 	actionOutput: string;
+	reminder?: string;
 }
 
 export const AGENT_PROTOCOL_PROMPT = `
@@ -102,6 +103,7 @@ export function buildContinuationMessage({
 	previousResponseJson,
 	previousGithubComment,
 	actionOutput,
+	reminder,
 }: ContinuationContext): string {
 	return [
 		"ORIGINAL TASK:",
@@ -118,10 +120,39 @@ export function buildContinuationMessage({
 		"LATEST ACTION OUTPUT:",
 		actionOutput,
 		"",
+		...(reminder ? ["IMPORTANT REMINDER:", reminder, ""] : []),
 		"Continue the same task. Do not restart or reinterpret the assignment.",
 		"Use the original task and your most recent structured response to decide the next step.",
 		`Continue the task using protocol "${AGENT_PROTOCOL_VERSION}".`,
 		"Return exactly one JSON object.",
+	].join("\n");
+}
+
+export function buildLoopRepairMessage(input: {
+	originalTask: string;
+	iteration: number;
+	previousResponseJson: string;
+	actionOutput: string;
+	repeatedCycleCount: number;
+}): string {
+	return [
+		"LOOP DETECTED:",
+		`You have repeated the same plan/action pattern ${input.repeatedCycleCount} times without meaningful progress.`,
+		"",
+		"ORIGINAL TASK:",
+		input.originalTask,
+		"",
+		`CURRENT ITERATION: ${input.iteration}`,
+		"",
+		"MOST RECENT STRUCTURED RESPONSE:",
+		input.previousResponseJson,
+		"",
+		"LATEST ACTION OUTPUT:",
+		input.actionOutput,
+		"",
+		"Do not repeat the same action again unless the repository state has changed.",
+		"Revise the plan and choose a materially different next step, or finish with a concise blocker summary if the task cannot progress safely.",
+		`Return exactly one JSON object using protocol "${AGENT_PROTOCOL_VERSION}".`,
 	].join("\n");
 }
 

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -2,18 +2,27 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { AgentAction } from "./agent_protocol.js";
 import { AGENT_PROTOCOL_VERSION } from "./agent_protocol.js";
 import { AgentRunner } from "./agent_runner.js";
 import type { ShellService } from "./shell.js";
 
 describe("AgentRunner", () => {
 	const makeFakeShell = (
-		executeActions: (actions: AgentAction[]) => Promise<string>,
+		executeCommand: (
+			command: string,
+			executionMode?: "read_only" | "read_write",
+		) => Promise<{
+			stdout: string;
+			stderr: string;
+			exitCode: number;
+		}>,
 	): ShellService =>
 		({
-			async executeActions(actions: AgentAction[]) {
-				return executeActions(actions);
+			async executeCommand(
+				command: string,
+				executionMode?: "read_only" | "read_write",
+			) {
+				return executeCommand(command, executionMode);
 			},
 		}) as unknown as ShellService;
 
@@ -25,7 +34,7 @@ describe("AgentRunner", () => {
 				next_step: "Inspect the repository root.",
 				actions: [
 					{ type: "run_ro_shell", command: "printf 'hello'" },
-					{ type: "run_shell", command: "printf 'world'" },
+					{ type: "run_ro_shell", command: "printf 'world'" },
 				],
 				task_status: "in_progress",
 			}),
@@ -55,22 +64,11 @@ describe("AgentRunner", () => {
 			},
 		};
 
-		const shell = makeFakeShell(async (actions) =>
-			actions
-				.filter(
-					(
-						action,
-					): action is Extract<
-						AgentAction,
-						{ type: "run_shell" | "run_ro_shell" }
-					> => action.type === "run_shell" || action.type === "run_ro_shell",
-				)
-				.map(
-					(action) =>
-						`\n--- EXECUTING: ${action.command} ---\nSTDOUT:\n${action.command.replace("printf ", "").replaceAll("'", "")}\nEXIT CODE: 0\n`,
-				)
-				.join(""),
-		);
+		const shell = makeFakeShell(async (command) => ({
+			stdout: command.replace("printf ", "").replaceAll("'", ""),
+			stderr: "",
+			exitCode: 0,
+		}));
 
 		const runner = new AgentRunner(shell);
 		const result = await runner.runAutonomousLoop(
@@ -80,6 +78,7 @@ describe("AgentRunner", () => {
 			5,
 			{
 				shellAccess: "read_write",
+				maxActionsPerTurn: 2,
 			},
 		);
 
@@ -139,9 +138,11 @@ describe("AgentRunner", () => {
 		};
 
 		const runner = new AgentRunner(
-			makeFakeShell(async () => {
-				return "";
-			}),
+			makeFakeShell(async () => ({
+				stdout: "",
+				stderr: "",
+				exitCode: 0,
+			})),
 		);
 		const result = await runner.runAutonomousLoop(
 			gemini as never,
@@ -199,10 +200,11 @@ describe("AgentRunner", () => {
 			},
 		};
 
-		const shell = makeFakeShell(
-			async () =>
-				"\n--- EXECUTING: printf 'ok' ---\nSTDOUT:\nok\nEXIT CODE: 0\n",
-		);
+		const shell = makeFakeShell(async () => ({
+			stdout: "ok",
+			stderr: "",
+			exitCode: 0,
+		}));
 		const runner = new AgentRunner(shell);
 		const result = await runner.runAutonomousLoop(
 			gemini as never,
@@ -249,7 +251,13 @@ describe("AgentRunner", () => {
 			},
 		};
 
-		const runner = new AgentRunner(makeFakeShell(async () => ""));
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
 		const result = await runner.runAutonomousLoop(
 			gemini as never,
 			"System instruction",
@@ -299,7 +307,13 @@ describe("AgentRunner", () => {
 			},
 		};
 
-		const runner = new AgentRunner(makeFakeShell(async () => ""));
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
 		const result = await runner.runAutonomousLoop(
 			gemini as never,
 			"System instruction",
@@ -348,9 +362,11 @@ describe("AgentRunner", () => {
 			};
 
 			const runner = new AgentRunner(
-				makeFakeShell(async () => {
-					return "";
-				}),
+				makeFakeShell(async () => ({
+					stdout: "",
+					stderr: "",
+					exitCode: 0,
+				})),
 			);
 			await runner.runAutonomousLoop(
 				gemini as never,
@@ -387,5 +403,220 @@ describe("AgentRunner", () => {
 			(capturedHistories[0] as Array<{ parts: Array<{ text: string }> }>)[0]
 				?.parts[0]?.text,
 		).toContain("Always read the plan first.");
+	});
+
+	it("rejects done after run_shell until persistence and read-only verification succeed", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the file.", "Return control."],
+				next_step: "Edit the file.",
+				actions: [{ type: "run_shell", command: "printf ok >> file.txt" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the file.", "Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Finished locally.",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Persist the file.", "Verify the branch.", "Return control."],
+				next_step: "Persist the file.",
+				actions: [{ type: "persist_work" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Persist the file.", "Verify the branch.", "Return control."],
+				next_step: "Verify the branch.",
+				actions: [
+					{
+						type: "run_ro_shell",
+						command: "git show origin/bot/issue-35:file.txt",
+					},
+				],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Persist the file.", "Verify the branch.", "Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Persisted and verified the change.",
+			}),
+		];
+
+		const sentMessages: string[] = [];
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async (_command, executionMode) => ({
+				stdout:
+					executionMode === "read_only"
+						? "persisted contents"
+						: "local write ok",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			8,
+			{
+				shellAccess: "read_write",
+				maxActionsPerTurn: 1,
+				persistWork: async () => ({
+					ok: true,
+					branch: "bot/issue-35",
+					commit_sha: "abc123",
+					changed_files: ["file.txt"],
+					message: "Persisted successfully.",
+				}),
+			},
+		);
+
+		expect(result.finalResponse).toBe("Persisted and verified the change.");
+		expect(sentMessages[2]).toContain('task_status "done" is not allowed');
+		expect(sentMessages[3]).toContain(
+			"Persistence succeeded. Run a read-only verification",
+		);
+	});
+
+	it("repairs repeated no-progress cycles and aborts after continued repetition", async () => {
+		const repeatingResponse = JSON.stringify({
+			version: AGENT_PROTOCOL_VERSION,
+			plan: ["Inspect package.json.", "Return control."],
+			next_step: "Inspect package.json.",
+			actions: [{ type: "run_ro_shell", command: "cat package.json" }],
+			task_status: "in_progress",
+		});
+		const responses = Array.from({ length: 6 }, () => repeatingResponse);
+		const sentMessages: string[] = [];
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "same output",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			8,
+			{
+				shellAccess: "read_only",
+				maxActionsPerTurn: 1,
+			},
+		);
+
+		expect(result.finalResponse).toContain(
+			"Stopped after repeated no-progress loops",
+		);
+		expect(
+			sentMessages.some((message) => message.includes("LOOP DETECTED:")),
+		).toBe(true);
+	});
+
+	it("rejects responses that exceed the configured action limit", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect files.", "Return control."],
+				next_step: "Inspect files.",
+				actions: [
+					{ type: "run_ro_shell", command: "pwd" },
+					{ type: "run_ro_shell", command: "ls" },
+				],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect files.", "Return control."],
+				next_step: "Inspect files.",
+				actions: [{ type: "run_ro_shell", command: "pwd" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect files.", "Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Completed safely.",
+			}),
+		];
+
+		const sentMessages: string[] = [];
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "ok",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			6,
+			{
+				shellAccess: "read_only",
+				maxActionsPerTurn: 1,
+			},
+		);
+
+		expect(result.finalResponse).toBe("Completed safely.");
+		expect(sentMessages[1]).toContain("actions may contain at most 1 item");
 	});
 });

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -1,9 +1,11 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Content } from "@google/generative-ai";
 import {
 	type AgentHandoffTarget,
 	buildContinuationMessage,
+	buildLoopRepairMessage,
 	buildProtocolRepairMessage,
 	type ParsedAgentProtocolResponse,
 	parseAgentProtocolResponse,
@@ -24,8 +26,10 @@ export interface IterationResult {
 export interface AgentRunnerOptions {
 	persistWork?: () => Promise<PersistWorkResult>;
 	requireDoneHandoff?: boolean;
+	loopAbortHandoffTo?: AgentHandoffTarget;
 	modelName?: string;
 	shellAccess?: ShellExecutionMode;
+	maxActionsPerTurn?: number;
 	promptDefinition?: {
 		botId: string;
 		displayName: string;
@@ -46,6 +50,28 @@ export interface AgentRunnerOptions {
 			content: string;
 		};
 	};
+}
+
+interface ExecutedActionRecord {
+	type: ParsedAgentProtocolResponse["protocol"]["actions"][number]["type"];
+	command?: string;
+	exitCode?: number;
+	ok?: boolean;
+	persistResult?: PersistWorkResult;
+}
+
+interface ActionExecutionResult {
+	output: string;
+	executedActions: ExecutedActionRecord[];
+}
+
+interface RunnerProgressState {
+	usedRunShell: boolean;
+	persistSucceededAfterWrite: boolean;
+	verifiedAfterPersist: boolean;
+	lastLoopFingerprint?: string;
+	repeatedCycleCount: number;
+	loopRepairsIssued: number;
 }
 
 export class AgentRunner {
@@ -87,6 +113,13 @@ export class AgentRunner {
 		const originalTask = initialMessage;
 		let currentMessage = initialMessage;
 		let iteration = 0;
+		const progressState: RunnerProgressState = {
+			usedRunShell: false,
+			persistSucceededAfterWrite: false,
+			verifiedAfterPersist: false,
+			repeatedCycleCount: 0,
+			loopRepairsIssued: 0,
+		};
 
 		while (iteration < maxIterations) {
 			iteration++;
@@ -140,6 +173,18 @@ export class AgentRunner {
 			});
 			this.log(`PROTOCOL RESPONSE: ${parsedResponse.rawJson}\n`);
 
+			const maxActionsPerTurn = options.maxActionsPerTurn ?? 1;
+			if (parsedResponse.protocol.actions.length > maxActionsPerTurn) {
+				const error = `actions may contain at most ${maxActionsPerTurn} item(s) for this persona, but you returned ${parsedResponse.protocol.actions.length}`;
+				logTrace("agent.iteration.protocolError", {
+					iteration,
+					error,
+					maxActionsPerTurn,
+				});
+				currentMessage = buildProtocolRepairMessage(error, responseText);
+				continue;
+			}
+
 			if (parsedResponse.protocol.task_status === "done") {
 				if (options.requireDoneHandoff && !parsedResponse.protocol.handoff_to) {
 					const error =
@@ -151,6 +196,18 @@ export class AgentRunner {
 					currentMessage = buildProtocolRepairMessage(error, responseText);
 					continue;
 				}
+				const doneValidationError = this.validateDoneResponse(progressState);
+				if (doneValidationError) {
+					logTrace("agent.iteration.protocolError", {
+						iteration,
+						error: doneValidationError,
+					});
+					currentMessage = buildProtocolRepairMessage(
+						doneValidationError,
+						responseText,
+					);
+					continue;
+				}
 				return {
 					finalResponse: parsedResponse.protocol.final_response || "",
 					handoffTo: parsedResponse.protocol.handoff_to,
@@ -158,10 +215,12 @@ export class AgentRunner {
 				};
 			}
 
-			const actionOutput = await this.executeActions(
+			const actionExecution = await this.executeActions(
 				parsedResponse.protocol.actions,
 				options,
 			);
+			this.updateProgressState(progressState, actionExecution.executedActions);
+			const actionOutput = actionExecution.output;
 			logTrace("agent.iteration.action", {
 				iteration,
 				actionTypes: parsedResponse.protocol.actions.map(
@@ -170,12 +229,53 @@ export class AgentRunner {
 				actionOutput: textStats(actionOutput),
 			});
 			this.log(`ACTION OUTPUT: ${actionOutput}\n`);
+
+			const loopFingerprint = this.buildLoopFingerprint(
+				parsedResponse,
+				actionExecution.executedActions,
+			);
+			if (loopFingerprint === progressState.lastLoopFingerprint) {
+				progressState.repeatedCycleCount += 1;
+			} else {
+				progressState.lastLoopFingerprint = loopFingerprint;
+				progressState.repeatedCycleCount = 0;
+				progressState.loopRepairsIssued = 0;
+			}
+
+			if (progressState.repeatedCycleCount >= 1) {
+				progressState.loopRepairsIssued += 1;
+				if (progressState.loopRepairsIssued >= 3) {
+					logTrace("agent.loop.abortedForRepeatedCycles", {
+						iteration,
+						repeatedCycleCount: progressState.repeatedCycleCount,
+						loopRepairsIssued: progressState.loopRepairsIssued,
+					});
+					return {
+						finalResponse:
+							"Stopped after repeated no-progress loops. The bot needs a revised task packet or a different recovery approach before continuing.",
+						handoffTo: options.loopAbortHandoffTo,
+						log: this.sessionLog,
+					};
+				}
+
+				currentMessage = buildLoopRepairMessage({
+					originalTask,
+					iteration,
+					previousResponseJson: parsedResponse.rawJson,
+					actionOutput,
+					repeatedCycleCount: progressState.repeatedCycleCount + 1,
+				});
+				continue;
+			}
+
+			const reminder = this.buildProgressReminder(progressState);
 			currentMessage = buildContinuationMessage({
 				originalTask,
 				iteration,
 				previousResponseJson: parsedResponse.rawJson,
 				previousGithubComment: parsedResponse.protocol.github_comment,
 				actionOutput,
+				reminder,
 			});
 		}
 
@@ -196,61 +296,194 @@ export class AgentRunner {
 	private async executeActions(
 		actions: ParsedAgentProtocolResponse["protocol"]["actions"],
 		options: AgentRunnerOptions,
-	): Promise<string> {
+	): Promise<ActionExecutionResult> {
 		if (actions.length === 0) {
-			return "ERROR: No actions were supplied.";
+			return {
+				output: "ERROR: No actions were supplied.",
+				executedActions: [],
+			};
 		}
 
 		const outputs: string[] = [];
+		const executedActions: ExecutedActionRecord[] = [];
 		const shellAccess = options.shellAccess ?? "read_write";
 
 		for (const action of actions) {
 			if (action.type === "run_ro_shell") {
-				outputs.push(await this.shell.executeActions([action]));
+				const result = await this.shell.executeCommand(
+					action.command,
+					"read_only",
+				);
+				executedActions.push({
+					type: action.type,
+					command: action.command,
+					exitCode: result.exitCode,
+					ok: result.exitCode === 0,
+				});
+				outputs.push(this.formatShellOutput(action.command, result));
 				continue;
 			}
 
 			if (action.type === "run_shell") {
 				if (shellAccess !== "read_write") {
-					outputs.push(
-						JSON.stringify(
-							{
-								ok: false,
-								error_code: "run_shell_not_available",
-								message:
-									'run_shell is not available for this persona. Use "run_ro_shell" instead.',
-							},
-							null,
-							2,
-						),
-					);
+					const denial = {
+						ok: false,
+						error_code: "run_shell_not_available",
+						message:
+							'run_shell is not available for this persona. Use "run_ro_shell" instead.',
+					};
+					executedActions.push({
+						type: action.type,
+						command: action.command,
+						ok: false,
+					});
+					outputs.push(JSON.stringify(denial, null, 2));
 					continue;
 				}
 
-				outputs.push(await this.shell.executeActions([action]));
+				const result = await this.shell.executeCommand(
+					action.command,
+					"read_write",
+				);
+				executedActions.push({
+					type: action.type,
+					command: action.command,
+					exitCode: result.exitCode,
+					ok: result.exitCode === 0,
+				});
+				outputs.push(this.formatShellOutput(action.command, result));
 				continue;
 			}
 
 			if (!options.persistWork) {
-				outputs.push(
-					JSON.stringify(
-						{
-							ok: false,
-							error_code: "persist_not_available",
-							message: "persist_work is not available for this persona.",
-						},
-						null,
-						2,
-					),
-				);
+				const denial = {
+					ok: false,
+					branch: "unavailable",
+					error_code: "persist_not_available",
+					message: "persist_work is not available for this persona.",
+				};
+				executedActions.push({
+					type: action.type,
+					ok: false,
+					persistResult: denial,
+				});
+				outputs.push(JSON.stringify(denial, null, 2));
 				continue;
 			}
 
 			const result = await options.persistWork();
+			executedActions.push({
+				type: action.type,
+				ok: result.ok,
+				persistResult: result,
+			});
 			outputs.push(JSON.stringify(result, null, 2));
 		}
 
-		return outputs.join("\n");
+		return {
+			output: outputs.join("\n"),
+			executedActions,
+		};
+	}
+
+	private formatShellOutput(
+		command: string,
+		result: Awaited<ReturnType<ShellService["executeCommand"]>>,
+	): string {
+		let output = `\n--- EXECUTING: ${command} ---\n`;
+		if (result.stdout) {
+			output += `STDOUT:\n${result.stdout}\n`;
+		}
+		if (result.stderr) {
+			output += `STDERR:\n${result.stderr}\n`;
+		}
+		output += `EXIT CODE: ${result.exitCode}\n`;
+		return output;
+	}
+
+	private updateProgressState(
+		state: RunnerProgressState,
+		executedActions: ExecutedActionRecord[],
+	): void {
+		for (const action of executedActions) {
+			if (action.type === "run_shell" && action.ok) {
+				state.usedRunShell = true;
+				state.persistSucceededAfterWrite = false;
+				state.verifiedAfterPersist = false;
+				continue;
+			}
+
+			if (action.type === "persist_work") {
+				if (state.usedRunShell && action.persistResult?.ok) {
+					state.persistSucceededAfterWrite = true;
+					state.verifiedAfterPersist = false;
+				}
+				continue;
+			}
+
+			if (
+				action.type === "run_ro_shell" &&
+				action.ok &&
+				state.usedRunShell &&
+				state.persistSucceededAfterWrite
+			) {
+				state.verifiedAfterPersist = true;
+			}
+		}
+	}
+
+	private validateDoneResponse(state: RunnerProgressState): string | null {
+		if (!state.usedRunShell) {
+			return null;
+		}
+
+		if (!state.persistSucceededAfterWrite) {
+			return 'task_status "done" is not allowed after a successful run_shell action until persist_work succeeds';
+		}
+
+		if (!state.verifiedAfterPersist) {
+			return 'task_status "done" is not allowed after persist_work until you verify the persisted branch state with run_ro_shell';
+		}
+
+		return null;
+	}
+
+	private buildProgressReminder(
+		state: RunnerProgressState,
+	): string | undefined {
+		if (!state.usedRunShell) {
+			return undefined;
+		}
+		if (!state.persistSucceededAfterWrite) {
+			return "You have used run_shell successfully in this task. Do not finish until persist_work succeeds.";
+		}
+		if (!state.verifiedAfterPersist) {
+			return "Persistence succeeded. Run a read-only verification against the persisted branch or file contents before finishing.";
+		}
+		return undefined;
+	}
+
+	private buildLoopFingerprint(
+		parsedResponse: ParsedAgentProtocolResponse,
+		executedActions: ExecutedActionRecord[],
+	): string {
+		const fingerprintPayload = {
+			plan: parsedResponse.protocol.plan,
+			nextStep: parsedResponse.protocol.next_step,
+			actions: parsedResponse.protocol.actions,
+			executedActions: executedActions.map((action) => ({
+				type: action.type,
+				command: action.command,
+				exitCode: action.exitCode,
+				ok: action.ok,
+				persistOk: action.persistResult?.ok,
+				persistErrorCode: action.persistResult?.error_code,
+				persistMessage: action.persistResult?.message,
+			})),
+		};
+		return createHash("sha256")
+			.update(JSON.stringify(fingerprintPayload))
+			.digest("hex");
 	}
 
 	private loadRepositoryGuidance(): {

--- a/src/utils/task_packet.test.ts
+++ b/src/utils/task_packet.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parseTaskPacket, renderTaskPacketForPrompt } from "./task_packet.js";
+
+describe("task_packet", () => {
+	it("parses the structured Developer Task handoff", () => {
+		const body = [
+			"I am the **Overseer**, and I am responding to issue #42 from @alice.",
+			"",
+			"Developer Task:",
+			"Task ID: auth-fix",
+			"Plan File: docs/plans/auth-fix.md",
+			"Files To Read:",
+			"- src/auth.ts",
+			"- src/auth.test.ts",
+			"Task Summary: Fix the expired-token branch so the API returns 401.",
+			"Done When: Expired tokens consistently produce a 401 response and the regression test passes.",
+			"Verification:",
+			"- npm test -- src/auth.test.ts",
+			"",
+			"Next step: @developer-tester to take action",
+		].join("\n");
+
+		const packet = parseTaskPacket(body);
+
+		expect(packet.hasStructuredHandoff).toBe(true);
+		expect(packet.taskId).toBe("auth-fix");
+		expect(packet.planFile).toBe("docs/plans/auth-fix.md");
+		expect(packet.filesToRead).toEqual([
+			"docs/plans/auth-fix.md",
+			"src/auth.ts",
+			"src/auth.test.ts",
+		]);
+		expect(packet.taskSummary).toContain("expired-token");
+		expect(packet.doneWhen).toContain("401 response");
+		expect(packet.verificationCommands).toEqual([
+			"npm test -- src/auth.test.ts",
+		]);
+	});
+
+	it("falls back to the directed task when no structured handoff exists", () => {
+		const packet = parseTaskPacket(
+			"I am the **Overseer**, and I am responding to issue #7 from @alice.\n\nPlease inspect src/index.ts and explain the bug.\n\nNext step: @quality to take action",
+		);
+
+		expect(packet.hasStructuredHandoff).toBe(false);
+		expect(packet.taskSummary).toBe(
+			"Please inspect src/index.ts and explain the bug.",
+		);
+		expect(packet.filesToRead).toEqual([]);
+		expect(packet.verificationCommands).toEqual([]);
+	});
+
+	it("renders a canonical packet for the worker prompt", () => {
+		const rendered = renderTaskPacketForPrompt(
+			parseTaskPacket(
+				[
+					"Developer Task:",
+					"Task ID: none",
+					"Plan File: docs/plans/one.md",
+					"Files To Read: src/one.ts, src/two.ts",
+					"Task Summary: Update the parser.",
+					"Done When: The parser accepts the new syntax.",
+					"Verification: npm test -- src/parser.test.ts",
+				].join("\n"),
+			),
+		);
+
+		expect(rendered).toContain("CANONICAL TASK PACKET:");
+		expect(rendered).toContain(
+			"Files To Read: docs/plans/one.md, src/one.ts, src/two.ts",
+		);
+		expect(rendered).toContain("Task Summary: Update the parser.");
+		expect(rendered).toContain("RAW DIRECTED TASK:");
+	});
+});

--- a/src/utils/task_packet.ts
+++ b/src/utils/task_packet.ts
@@ -1,0 +1,205 @@
+import { extractDirectedTask } from "./persona_helper.js";
+
+export interface TaskPacket {
+	rawBody: string;
+	directedTask: string;
+	hasStructuredHandoff: boolean;
+	taskId?: string;
+	planFile?: string;
+	filesToRead: string[];
+	taskSummary: string;
+	doneWhen?: string;
+	verificationCommands: string[];
+	supplementalContext?: string;
+}
+
+type StructuredTaskFields = {
+	taskId?: string;
+	planFile?: string;
+	filesToRead: string[];
+	taskSummary?: string;
+	doneWhen?: string;
+	verificationCommands: string[];
+};
+
+export function parseTaskPacket(body: string): TaskPacket {
+	const directedTask = extractDirectedTask(body);
+	const marker = "Developer Task:";
+	const markerIndex = directedTask.indexOf(marker);
+	if (markerIndex < 0) {
+		return {
+			rawBody: body,
+			directedTask,
+			hasStructuredHandoff: false,
+			filesToRead: [],
+			taskSummary: directedTask,
+			verificationCommands: [],
+		};
+	}
+
+	const supplementalContext = directedTask.slice(0, markerIndex).trim();
+	const structuredBlock = directedTask
+		.slice(markerIndex + marker.length)
+		.trim();
+	const parsed = parseStructuredTaskFields(structuredBlock);
+	const filesToRead = Array.from(
+		new Set(
+			[parsed.planFile, ...parsed.filesToRead]
+				.map(normalizeOptionalValue)
+				.filter((value): value is string => Boolean(value)),
+		),
+	);
+	const taskSummary =
+		normalizeOptionalValue(parsed.taskSummary) ||
+		supplementalContext ||
+		directedTask;
+
+	return {
+		rawBody: body,
+		directedTask,
+		hasStructuredHandoff: true,
+		taskId: normalizeOptionalValue(parsed.taskId),
+		planFile: normalizeOptionalValue(parsed.planFile),
+		filesToRead,
+		taskSummary,
+		doneWhen: normalizeOptionalValue(parsed.doneWhen),
+		verificationCommands: parsed.verificationCommands
+			.map((command) => command.trim())
+			.filter(Boolean),
+		supplementalContext: supplementalContext || undefined,
+	};
+}
+
+export function renderTaskPacketForPrompt(packet: TaskPacket): string {
+	const lines = [
+		"CANONICAL TASK PACKET:",
+		`- Structured handoff: ${packet.hasStructuredHandoff ? "yes" : "no"}`,
+		`- Task ID: ${packet.taskId || "none"}`,
+		`- Plan File: ${packet.planFile || "none"}`,
+		`- Files To Read: ${packet.filesToRead.length > 0 ? packet.filesToRead.join(", ") : "none"}`,
+		`- Task Summary: ${packet.taskSummary}`,
+		`- Done When: ${packet.doneWhen || "none"}`,
+		`- Verification: ${
+			packet.verificationCommands.length > 0
+				? packet.verificationCommands.join(" | ")
+				: "none"
+		}`,
+	];
+
+	if (packet.supplementalContext) {
+		lines.push("", "SUPPLEMENTAL CONTEXT:", packet.supplementalContext);
+	}
+
+	lines.push("", "RAW DIRECTED TASK:", packet.directedTask);
+	return `${lines.join("\n")}\n`;
+}
+
+function parseStructuredTaskFields(block: string): StructuredTaskFields {
+	const result: StructuredTaskFields = {
+		filesToRead: [],
+		verificationCommands: [],
+	};
+	const lines = block.split(/\r?\n/);
+	let activeListKey: "filesToRead" | "verificationCommands" | null = null;
+	let activeScalarKey: "taskSummary" | "doneWhen" | null = null;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) {
+			activeListKey = null;
+			activeScalarKey = null;
+			continue;
+		}
+
+		const listItem = trimmed.match(/^-\s+(.+)$/);
+		if (listItem && activeListKey) {
+			const value = normalizeOptionalValue(listItem[1]);
+			if (value) {
+				result[activeListKey].push(value);
+			}
+			continue;
+		}
+
+		const keyMatch = trimmed.match(
+			/^(Task ID|Plan File|Files To Read|Task Summary|Done When|Verification):\s*(.*)$/i,
+		);
+		if (keyMatch) {
+			activeListKey = null;
+			activeScalarKey = null;
+			const rawKey = keyMatch[1]?.toLowerCase();
+			const rawValue = keyMatch[2] || "";
+
+			if (rawKey === "task id") {
+				result.taskId = rawValue.trim();
+				continue;
+			}
+			if (rawKey === "plan file") {
+				result.planFile = rawValue.trim();
+				continue;
+			}
+			if (rawKey === "files to read") {
+				const values = splitFilesToRead(rawValue);
+				result.filesToRead.push(...values);
+				activeListKey = rawValue.trim().length === 0 ? "filesToRead" : null;
+				continue;
+			}
+			if (rawKey === "task summary") {
+				result.taskSummary = rawValue.trim();
+				activeScalarKey = "taskSummary";
+				continue;
+			}
+			if (rawKey === "done when") {
+				result.doneWhen = rawValue.trim();
+				activeScalarKey = "doneWhen";
+				continue;
+			}
+			if (rawKey === "verification") {
+				const value = normalizeOptionalValue(rawValue);
+				if (value) {
+					result.verificationCommands.push(value);
+				}
+				activeListKey =
+					rawValue.trim().length === 0 ? "verificationCommands" : null;
+			}
+			continue;
+		}
+
+		if (activeScalarKey) {
+			const nextValue = [result[activeScalarKey], trimmed]
+				.filter(Boolean)
+				.join(" ")
+				.trim();
+			result[activeScalarKey] = nextValue;
+		}
+	}
+
+	result.filesToRead = Array.from(new Set(result.filesToRead));
+	result.verificationCommands = Array.from(
+		new Set(
+			result.verificationCommands.map((value) => value.trim()).filter(Boolean),
+		),
+	);
+	return result;
+}
+
+function splitFilesToRead(value: string): string[] {
+	const normalized = normalizeOptionalValue(value);
+	if (!normalized) {
+		return [];
+	}
+	return normalized
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+function normalizeOptionalValue(value?: string): string | undefined {
+	if (!value) {
+		return undefined;
+	}
+	const trimmed = value.trim();
+	if (trimmed.length === 0 || trimmed.toLowerCase() === "none") {
+		return undefined;
+	}
+	return trimmed;
+}


### PR DESCRIPTION
## What changed

This PR tightens the task-bot execution contract so the worker personas spend fewer turns looping and follow their handoff packets more closely.

- adds normalized task-packet parsing for structured `Developer Task` handoffs, including `Done When` and `Verification`
- adds per-bot `max_actions_per_turn` config plus stricter developer/planner/quality iteration budgets
- teaches the runner to detect repeated no-progress cycles, inject loop-repair prompts, and abort repeated thrash earlier
- enforces write completion in the runner: after successful `run_shell`, bots must `persist_work` and then verify with `run_ro_shell` before they can finish
- strengthens the shared task/developer/persistence prompts and the Overseer handoff format to emphasize narrow next steps and explicit success criteria
- adds `src/scripts/inspect_run.ts`, which can download workflow artifacts for a run and render a markdown flow report for postmortem inspection

## Why

The current bots, especially `developer-tester`, were prone to re-running the same inspection, persistence, or verification steps without revising their plan. The runner previously only repaired malformed protocol output, so valid-but-stale loops could continue until max iterations.

## Impact

- task bots receive cleaner, more structured assignments
- repeated identical action/plan cycles are surfaced and interrupted earlier
- successful repository writes now require persistence and post-persist verification before completion
- failed runs are easier to inspect afterward using the generated markdown report from downloaded artifacts

## Validation

- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
