### PR TITLE
[codex] Make developer handoffs incremental

### DIFF
--- a/prompts/developer-tester.md
+++ b/prompts/developer-tester.md
@@ -1,21 +1,30 @@
-You implement code and verification for the assigned task.
+You implement code and verification for one small assigned increment.
 
 Use a plan-act-verify cycle:
 
-- understand the task packet before touching the repository
+- understand the planner's plan and the task packet before touching the repository
 - read the named plan file and files-to-read first
-- inspect only the files needed to execute the task summary
-- make the smallest implementation change that satisfies `Done When`
-- run the smallest useful verification commands from the task packet
+- identify the current step and implement the smallest useful increment that makes real progress
+- stop after the increment described by `Stop After` and `Done When`
+- run only the narrow verification and progress-evidence commands needed for that increment
 - persist the work
 - verify the persisted branch state before finishing
+- hand control back to Overseer with a concise progress update
 
 Developer/Tester guardrails:
 
 - default to exactly one action per turn
+- do not try to finish the entire plan in one run unless the task packet explicitly says this increment is final
+- after understanding the planner's step, bias toward making a small code change rather than gathering more context
+- once you have completed one meaningful increment, stop and return control instead of rolling into the next likely step
 - do not spend multiple turns re-listing directories or rereading the same file without a reason
 - do not rerun the same failing test or persistence step unless you changed code, commands, or environment
 - if the task packet is missing required detail, say so explicitly in the final summary instead of inventing scope
 - if the requested files or plan do not exist, verify that once and then stop with a blocker rather than searching the whole repo repeatedly
 
-Your final response should summarize the changes you implemented and the verification results.
+Your final response should summarize:
+
+- what increment you completed
+- what you changed
+- what you verified
+- what remains for Overseer to review or assign next

--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -2,7 +2,7 @@ Current available bots:
 
 - `@product-architect`: requirements and high-level design
 - `@planner`: task decomposition and planning
-- `@developer-tester`: implementation and testing
+- `@developer-tester`: small-step implementation and testing
 - `@quality`: verification and review
 
 When assigning work to `@developer-tester`, include a structured handoff block in the GitHub comment body:
@@ -12,15 +12,24 @@ Task ID: <task identifier or "none">
 Plan File: <repo path or "none">
 Files To Read:
 - <repo path>
-Task Summary: <single actionable sentence>
-Done When: <single sentence describing the observable completion condition>
+Current Step: <where this increment sits in the planner's plan>
+Smallest Useful Increment: <single actionable sentence describing the one increment to implement now>
+Stop After: <single sentence describing where this run must stop>
+Task Summary: <single actionable sentence describing the broader purpose of the increment>
+Done When: <single sentence describing the observable completion condition for this increment>
+Progress Evidence:
+- <repo command or artifact that proves the increment happened>
 Verification:
 - <repo command>
+Likely Next Step: <short suggestion for what Overseer should consider assigning next>
 
 Requirements for Overseer handoffs:
 
-- every developer task must define `Done When`
+- every developer task must define `Current Step`, `Smallest Useful Increment`, `Stop After`, and `Done When`
+- write `Done When` for the current increment, not the whole issue
 - include at least one targeted verification command whenever you can
+- include at least one `Progress Evidence` item that helps you review what changed before assigning the next increment
+- keep developer tasks narrow enough that Overseer can inspect the result and decide the next step
 - list only the files the worker actually needs first; avoid broad repo scavenger hunts
 - if the latest responder claims a file changed, inspect that file before delegating follow-up work
 

--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -35,6 +35,7 @@ Rules:
 - If the task is complete, return `"task_status": "done"`, `"actions": []`, and a non-empty `final_response`.
 - `handoff_to`, when present, must be one of `@overseer`, `@product-architect`, `@planner`, `@developer-tester`, `@quality`, or `human_review_required`.
 - If you set `handoff_to`, the dispatcher will append the standardized `Next step: ...` line when it posts your final GitHub comment.
+- For incremental implementation tasks, `"done"` means the assigned increment is complete and ready for review, not that the whole issue is finished.
 - Do not use markdown fences or prose outside the JSON object.
 - If the previous turn failed or repeated, revise the plan and choose a materially different next step before continuing.
 
@@ -61,15 +62,15 @@ Example done response object:
 {
   "version": "{{AGENT_PROTOCOL_VERSION}}",
   "plan": [
-    "Inspect the relevant plan and implementation files.",
-    "Make the minimal code change required by the task.",
-    "Run targeted verification.",
-    "Persist the work and confirm it exists on the issue branch."
+    "Read the named plan and implementation files to understand the current increment.",
+    "Make the smallest code change that completes this increment.",
+    "Run targeted verification and persist the work.",
+    "Return control with a progress update."
   ],
-  "next_step": "Return control to the dispatcher.",
+  "next_step": "Return control with an incremental progress summary.",
   "actions": [],
   "task_status": "done",
-  "handoff_to": "@planner",
-  "final_response": "Identified the relevant implementation touchpoints and prepared the planner handoff."
+  "handoff_to": "@overseer",
+  "final_response": "Completed the current increment, verified the focused check, and persisted the change. Remaining work should continue in the next Overseer-assigned increment."
 }
 ```

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -1,20 +1,25 @@
-You are a task-execution bot. Your job is to receive a task and execute it in the repository.
+You are a task-execution bot. Your job is to receive a task and make one meaningful increment of repository progress.
 
 The dynamic task input is the canonical assignment. Do not wait for a second hidden instruction layer from the dispatcher.
 
 Treat the task packet as binding:
 
-- read the explicitly named files before broader exploration
-- use the `Task Summary` as the implementation goal
-- use `Done When` as the completion bar
-- use `Verification` as the default verification checklist unless the repository proves a command is invalid
+- read the planner's plan and the explicitly named files before broader exploration
+- use `Current Step` to understand where you are in the planner's plan
+- use `Smallest Useful Increment` as the immediate implementation goal
+- use `Stop After` and `Done When` as the stopping boundary for this run
+- use `Progress Evidence` and `Verification` as the default evidence checklist unless the repository proves a command is invalid
+- treat `Likely Next Step` as context for your hand-back summary, not as permission to continue into the next increment yourself
 
 Use the JSON action protocol to inspect the repository, verify results, and make changes only when your available actions permit it.
 
 Execution discipline:
 
 - write a short concrete plan on the first turn and revise it only when the evidence changes
+- the first step is to understand the planner's plan and the current step, then implement the smallest useful increment that makes progress
 - keep the next step narrowly scoped to one immediate action
+- do not try to finish the whole planner document unless the task packet explicitly makes this run the final increment
+- once one meaningful increment is complete, stop, report progress, and return control to Overseer
 - after at most two inspection turns, either start editing, run verification, or explain the blocker
 - if a command fails, change the approach or the repository state before retrying
 - if you are blocked after two materially different attempts, stop looping and return control with a concise blocker summary

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -20,7 +20,7 @@ describe("bot_config", () => {
 			"You are operating inside a repository checkout on GitHub Actions",
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain(
-			"You implement code and verification for the assigned task.",
+			"You implement code and verification for one small assigned increment.",
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain(
 			'"type":"run_ro_shell"',

--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -212,6 +212,8 @@ I will comply.
 		expect(message).toContain("Reading the plan before changing code.");
 		expect(message).toContain("LATEST ACTION OUTPUT:");
 		expect(message).toContain("Plan contents");
+		expect(message).toContain("Continue the same assigned increment.");
+		expect(message).toContain("return control with a concise progress update");
 		expect(message).toContain(
 			'Continue the task using protocol "overseer/v1".',
 		);

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -121,8 +121,9 @@ export function buildContinuationMessage({
 		actionOutput,
 		"",
 		...(reminder ? ["IMPORTANT REMINDER:", reminder, ""] : []),
-		"Continue the same task. Do not restart or reinterpret the assignment.",
-		"Use the original task and your most recent structured response to decide the next step.",
+		"Continue the same assigned increment. Do not restart or expand the assignment.",
+		"Use the original task packet and your most recent structured response to decide the next immediate step.",
+		"If the current increment is complete, return control with a concise progress update instead of starting the next increment.",
 		`Continue the task using protocol "${AGENT_PROTOCOL_VERSION}".`,
 		"Return exactly one JSON object.",
 	].join("\n");

--- a/src/utils/task_packet.test.ts
+++ b/src/utils/task_packet.test.ts
@@ -12,10 +12,16 @@ describe("task_packet", () => {
 			"Files To Read:",
 			"- src/auth.ts",
 			"- src/auth.test.ts",
+			"Current Step: Fix the expired-token handling branch.",
+			"Smallest Useful Increment: Update src/auth.ts so expired tokens return 401 before touching broader auth flows.",
+			"Stop After: src/auth.ts returns 401 for expired tokens and the targeted regression test passes.",
 			"Task Summary: Fix the expired-token branch so the API returns 401.",
 			"Done When: Expired tokens consistently produce a 401 response and the regression test passes.",
+			"Progress Evidence:",
+			"- git diff -- src/auth.ts src/auth.test.ts",
 			"Verification:",
 			"- npm test -- src/auth.test.ts",
+			"Likely Next Step: Have Overseer verify the diff and decide whether any auth cleanup remains.",
 			"",
 			"Next step: @developer-tester to take action",
 		].join("\n");
@@ -30,11 +36,18 @@ describe("task_packet", () => {
 			"src/auth.ts",
 			"src/auth.test.ts",
 		]);
+		expect(packet.currentStep).toContain("expired-token handling");
+		expect(packet.smallestUsefulIncrement).toContain("src/auth.ts");
+		expect(packet.stopAfter).toContain("targeted regression test");
 		expect(packet.taskSummary).toContain("expired-token");
 		expect(packet.doneWhen).toContain("401 response");
+		expect(packet.progressEvidence).toEqual([
+			"git diff -- src/auth.ts src/auth.test.ts",
+		]);
 		expect(packet.verificationCommands).toEqual([
 			"npm test -- src/auth.test.ts",
 		]);
+		expect(packet.likelyNextStep).toContain("Overseer verify");
 	});
 
 	it("falls back to the directed task when no structured handoff exists", () => {
@@ -47,6 +60,7 @@ describe("task_packet", () => {
 			"Please inspect src/index.ts and explain the bug.",
 		);
 		expect(packet.filesToRead).toEqual([]);
+		expect(packet.progressEvidence).toEqual([]);
 		expect(packet.verificationCommands).toEqual([]);
 	});
 
@@ -58,9 +72,14 @@ describe("task_packet", () => {
 					"Task ID: none",
 					"Plan File: docs/plans/one.md",
 					"Files To Read: src/one.ts, src/two.ts",
+					"Current Step: Update the parser incrementally.",
+					"Smallest Useful Increment: Teach the parser about one new token.",
+					"Stop After: The parser accepts the new token and one focused test passes.",
 					"Task Summary: Update the parser.",
 					"Done When: The parser accepts the new syntax.",
+					"Progress Evidence: git diff -- src/one.ts",
 					"Verification: npm test -- src/parser.test.ts",
+					"Likely Next Step: Expand coverage to the next token case.",
 				].join("\n"),
 			),
 		);
@@ -68,6 +87,13 @@ describe("task_packet", () => {
 		expect(rendered).toContain("CANONICAL TASK PACKET:");
 		expect(rendered).toContain(
 			"Files To Read: docs/plans/one.md, src/one.ts, src/two.ts",
+		);
+		expect(rendered).toContain(
+			"Smallest Useful Increment: Teach the parser about one new token.",
+		);
+		expect(rendered).toContain("Progress Evidence: git diff -- src/one.ts");
+		expect(rendered).toContain(
+			"Likely Next Step: Expand coverage to the next token case.",
 		);
 		expect(rendered).toContain("Task Summary: Update the parser.");
 		expect(rendered).toContain("RAW DIRECTED TASK:");

--- a/src/utils/task_packet.ts
+++ b/src/utils/task_packet.ts
@@ -7,9 +7,14 @@ export interface TaskPacket {
 	taskId?: string;
 	planFile?: string;
 	filesToRead: string[];
+	currentStep?: string;
+	smallestUsefulIncrement?: string;
+	stopAfter?: string;
 	taskSummary: string;
 	doneWhen?: string;
+	progressEvidence: string[];
 	verificationCommands: string[];
+	likelyNextStep?: string;
 	supplementalContext?: string;
 }
 
@@ -17,9 +22,14 @@ type StructuredTaskFields = {
 	taskId?: string;
 	planFile?: string;
 	filesToRead: string[];
+	currentStep?: string;
+	smallestUsefulIncrement?: string;
+	stopAfter?: string;
 	taskSummary?: string;
 	doneWhen?: string;
+	progressEvidence: string[];
 	verificationCommands: string[];
+	likelyNextStep?: string;
 };
 
 export function parseTaskPacket(body: string): TaskPacket {
@@ -33,6 +43,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 			hasStructuredHandoff: false,
 			filesToRead: [],
 			taskSummary: directedTask,
+			progressEvidence: [],
 			verificationCommands: [],
 		};
 	}
@@ -61,11 +72,20 @@ export function parseTaskPacket(body: string): TaskPacket {
 		taskId: normalizeOptionalValue(parsed.taskId),
 		planFile: normalizeOptionalValue(parsed.planFile),
 		filesToRead,
+		currentStep: normalizeOptionalValue(parsed.currentStep),
+		smallestUsefulIncrement: normalizeOptionalValue(
+			parsed.smallestUsefulIncrement,
+		),
+		stopAfter: normalizeOptionalValue(parsed.stopAfter),
 		taskSummary,
 		doneWhen: normalizeOptionalValue(parsed.doneWhen),
+		progressEvidence: parsed.progressEvidence
+			.map((value) => value.trim())
+			.filter(Boolean),
 		verificationCommands: parsed.verificationCommands
 			.map((command) => command.trim())
 			.filter(Boolean),
+		likelyNextStep: normalizeOptionalValue(parsed.likelyNextStep),
 		supplementalContext: supplementalContext || undefined,
 	};
 }
@@ -77,13 +97,22 @@ export function renderTaskPacketForPrompt(packet: TaskPacket): string {
 		`- Task ID: ${packet.taskId || "none"}`,
 		`- Plan File: ${packet.planFile || "none"}`,
 		`- Files To Read: ${packet.filesToRead.length > 0 ? packet.filesToRead.join(", ") : "none"}`,
+		`- Current Step: ${packet.currentStep || "none"}`,
+		`- Smallest Useful Increment: ${packet.smallestUsefulIncrement || "none"}`,
+		`- Stop After: ${packet.stopAfter || "none"}`,
 		`- Task Summary: ${packet.taskSummary}`,
 		`- Done When: ${packet.doneWhen || "none"}`,
+		`- Progress Evidence: ${
+			packet.progressEvidence.length > 0
+				? packet.progressEvidence.join(" | ")
+				: "none"
+		}`,
 		`- Verification: ${
 			packet.verificationCommands.length > 0
 				? packet.verificationCommands.join(" | ")
 				: "none"
 		}`,
+		`- Likely Next Step: ${packet.likelyNextStep || "none"}`,
 	];
 
 	if (packet.supplementalContext) {
@@ -97,11 +126,23 @@ export function renderTaskPacketForPrompt(packet: TaskPacket): string {
 function parseStructuredTaskFields(block: string): StructuredTaskFields {
 	const result: StructuredTaskFields = {
 		filesToRead: [],
+		progressEvidence: [],
 		verificationCommands: [],
 	};
 	const lines = block.split(/\r?\n/);
-	let activeListKey: "filesToRead" | "verificationCommands" | null = null;
-	let activeScalarKey: "taskSummary" | "doneWhen" | null = null;
+	let activeListKey:
+		| "filesToRead"
+		| "progressEvidence"
+		| "verificationCommands"
+		| null = null;
+	let activeScalarKey:
+		| "currentStep"
+		| "smallestUsefulIncrement"
+		| "stopAfter"
+		| "taskSummary"
+		| "doneWhen"
+		| "likelyNextStep"
+		| null = null;
 
 	for (const line of lines) {
 		const trimmed = line.trim();
@@ -121,7 +162,7 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 		}
 
 		const keyMatch = trimmed.match(
-			/^(Task ID|Plan File|Files To Read|Task Summary|Done When|Verification):\s*(.*)$/i,
+			/^(Task ID|Plan File|Files To Read|Current Step|Smallest Useful Increment|Stop After|Task Summary|Done When|Progress Evidence|Verification|Likely Next Step):\s*(.*)$/i,
 		);
 		if (keyMatch) {
 			activeListKey = null;
@@ -143,6 +184,21 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 				activeListKey = rawValue.trim().length === 0 ? "filesToRead" : null;
 				continue;
 			}
+			if (rawKey === "current step") {
+				result.currentStep = rawValue.trim();
+				activeScalarKey = "currentStep";
+				continue;
+			}
+			if (rawKey === "smallest useful increment") {
+				result.smallestUsefulIncrement = rawValue.trim();
+				activeScalarKey = "smallestUsefulIncrement";
+				continue;
+			}
+			if (rawKey === "stop after") {
+				result.stopAfter = rawValue.trim();
+				activeScalarKey = "stopAfter";
+				continue;
+			}
 			if (rawKey === "task summary") {
 				result.taskSummary = rawValue.trim();
 				activeScalarKey = "taskSummary";
@@ -153,6 +209,15 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 				activeScalarKey = "doneWhen";
 				continue;
 			}
+			if (rawKey === "progress evidence") {
+				const value = normalizeOptionalValue(rawValue);
+				if (value) {
+					result.progressEvidence.push(value);
+				}
+				activeListKey =
+					rawValue.trim().length === 0 ? "progressEvidence" : null;
+				continue;
+			}
 			if (rawKey === "verification") {
 				const value = normalizeOptionalValue(rawValue);
 				if (value) {
@@ -160,6 +225,11 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 				}
 				activeListKey =
 					rawValue.trim().length === 0 ? "verificationCommands" : null;
+				continue;
+			}
+			if (rawKey === "likely next step") {
+				result.likelyNextStep = rawValue.trim();
+				activeScalarKey = "likelyNextStep";
 			}
 			continue;
 		}
@@ -174,6 +244,11 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 	}
 
 	result.filesToRead = Array.from(new Set(result.filesToRead));
+	result.progressEvidence = Array.from(
+		new Set(
+			result.progressEvidence.map((value) => value.trim()).filter(Boolean),
+		),
+	);
 	result.verificationCommands = Array.from(
 		new Set(
 			result.verificationCommands.map((value) => value.trim()).filter(Boolean),


### PR DESCRIPTION
## What changed

This changes the developer workflow from "finish the assigned task" to "complete one meaningful increment, persist it, and hand control back to Overseer."

The main pieces are:
- expand the structured `Developer Task` packet with increment-oriented fields such as `Current Step`, `Smallest Useful Increment`, `Stop After`, `Progress Evidence`, and `Likely Next Step`
- rewrite the shared task-agent and developer-tester prompts around small-step execution and hand-back to Overseer
- update the shared agent protocol wording so a `done` response can mean "this increment is complete and ready for review"
- update continuation messaging so the worker is reminded to continue the same increment and not roll into the next one

## Why

The goal is to make `developer-tester` act more like an incremental executor than an end-to-end finisher:
- read the planner's plan
- make one small concrete change
- verify that increment
- persist it
- return control to Overseer for inspection and the next assignment

That should make it easier for the worker to take action promptly and easier for Overseer to steer the task step by step.

## Validation

- `npx vitest run src/utils/task_packet.test.ts src/utils/agent_protocol.test.ts`
- `npx tsc --noEmit`
- `npm test`
