### PR TITLE
Raise developer-tester max iterations to 50

### DIFF
--- a/bots.json
+++ b/bots.json
@@ -60,7 +60,7 @@
       "kind": "task",
       "shell_access": "read_write",
       "allow_persist_work": true,
-      "max_iterations": 12,
+      "max_iterations": 50,
       "max_actions_per_turn": 1,
       "prompt_files": [
         "prompts/shared/task-agent.md",


### PR DESCRIPTION
## Summary
- raise `developer-tester` max iterations from 12 to 50
- leave all other bot settings and prompts unchanged

## Validation
- `npx biome check src/`
- `npx tsc --noEmit`
- `npm test`
