### PR TITLE
[codex] Let developer-tester hand back after persist

### DIFF
--- a/bots.json
+++ b/bots.json
@@ -60,6 +60,7 @@
       "kind": "task",
       "shell_access": "read_write",
       "allow_persist_work": true,
+      "require_post_persist_verification": false,
       "max_iterations": 50,
       "max_actions_per_turn": 1,
       "prompt_files": [

--- a/prompts/developer-tester.md
+++ b/prompts/developer-tester.md
@@ -8,14 +8,14 @@ Use a plan-act-verify cycle:
 - stop after the increment described by `Stop After` and `Done When`
 - run only the narrow verification and progress-evidence commands needed for that increment
 - persist the work
-- verify the persisted branch state before finishing
-- hand control back to Overseer with a concise progress update
+- hand control back to Overseer with a concise progress update once local verification and persistence succeed
 
 Developer/Tester guardrails:
 
 - default to exactly one action per turn
 - do not try to finish the entire plan in one run unless the task packet explicitly says this increment is final
 - after understanding the planner's step, bias toward making a small code change rather than gathering more context
+- do not perform extra remote-branch verification after `persist_work`; Overseer is responsible for reviewing the persisted result
 - once you have completed one meaningful increment, stop and return control instead of rolling into the next likely step
 - do not spend multiple turns re-listing directories or rereading the same file without a reason
 - do not rerun the same failing test or persistence step unless you changed code, commands, or environment

--- a/prompts/partials/post-persist-completion-rules/handoff-to-overseer.md
+++ b/prompts/partials/post-persist-completion-rules/handoff-to-overseer.md
@@ -1,0 +1,1 @@
+- after persistence, hand control back to Overseer; Overseer is responsible for reviewing the persisted branch state

--- a/prompts/partials/post-persist-completion-rules/require-verification.md
+++ b/prompts/partials/post-persist-completion-rules/require-verification.md
@@ -1,0 +1,1 @@
+- after persistence, run at least one `run_ro_shell` verification command that inspects `origin/bot/issue-<n>` or the persisted file contents before concluding

--- a/prompts/shared/persisting-agent.md
+++ b/prompts/shared/persisting-agent.md
@@ -13,4 +13,4 @@ Completion requirements after any successful `run_shell` action:
 - you are not done when a local file exists
 - you are not done when local tests pass
 - you are done only after `persist_work` succeeds
-- after persistence, run at least one `run_ro_shell` verification command that inspects `origin/bot/issue-<n>` or the persisted file contents before concluding
+{{POST_PERSIST_COMPLETION_RULES}}

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -9,6 +9,7 @@ describe("bot_config", () => {
 		expect(developer.kind).toBe("task");
 		expect(developer.shellAccess).toBe("read_write");
 		expect(developer.allowPersistWork).toBe(true);
+		expect(developer.requirePostPersistVerification).toBe(false);
 		expect(developer.maxActionsPerTurn).toBe(1);
 		expect(developer.prompt.promptFiles).toContain(
 			"prompts/shared/agent-protocol.md",
@@ -40,6 +41,9 @@ describe("bot_config", () => {
 		expect(getBotOrThrow(registry, "overseer").kind).toBe("overseer");
 		expect(getBotOrThrow(registry, "quality").shellAccess).toBe("read_only");
 		expect(getBotOrThrow(registry, "quality").allowPersistWork).toBe(false);
+		expect(
+			getBotOrThrow(registry, "quality").requirePostPersistVerification,
+		).toBe(true);
 		expect(getBotOrThrow(registry, "overseer").maxActionsPerTurn).toBe(2);
 		expect(
 			getBotOrThrow(registry, "quality").prompt.concatenatedPrompt,

--- a/src/bots/bot_config.ts
+++ b/src/bots/bot_config.ts
@@ -32,6 +32,7 @@ interface RawBotDefinition {
 	};
 	prompt_files?: string[];
 	allow_persist_work?: boolean;
+	require_post_persist_verification?: boolean;
 	max_iterations?: number;
 	max_actions_per_turn?: number;
 }
@@ -52,6 +53,7 @@ export interface LoadedBotDefinition {
 	};
 	shellAccess: ShellAccess;
 	allowPersistWork: boolean;
+	requirePostPersistVerification: boolean;
 	maxIterations: number;
 	maxActionsPerTurn: number;
 	prompt: LoadedPromptAssembly;
@@ -144,6 +146,8 @@ function loadBotDefinition(
 		`${id}.llm.model`,
 	);
 	const allowPersistWork = Boolean(rawBot.allow_persist_work);
+	const requirePostPersistVerification =
+		rawBot.require_post_persist_verification ?? true;
 	const maxIterations = parsePositiveInteger(
 		rawBot.max_iterations ?? defaults.defaultMaxIterations,
 		`${id}.max_iterations`,
@@ -170,11 +174,13 @@ function loadBotDefinition(
 		},
 		shellAccess,
 		allowPersistWork,
+		requirePostPersistVerification,
 		maxIterations,
 		maxActionsPerTurn,
 		prompt: loadPromptAssembly(repoRoot, promptFiles, {
 			shellAccess,
 			allowPersistWork,
+			requirePostPersistVerification,
 			maxActionsPerTurn,
 		}),
 	};
@@ -186,6 +192,7 @@ function loadPromptAssembly(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
 		maxActionsPerTurn: number;
 	},
 ): LoadedPromptAssembly {
@@ -221,6 +228,7 @@ function renderPromptTemplate(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
 		maxActionsPerTurn: number;
 	},
 ): string {
@@ -237,6 +245,10 @@ function renderPromptTemplate(
 		.replaceAll(
 			"{{SHELL_ACTION_RULES}}",
 			buildShellActionRules(repoRoot, context),
+		)
+		.replaceAll(
+			"{{POST_PERSIST_COMPLETION_RULES}}",
+			buildPostPersistCompletionRules(repoRoot, context),
 		)
 		.replaceAll("{{MAX_ACTIONS_PER_TURN}}", String(context.maxActionsPerTurn))
 		.replaceAll(
@@ -308,6 +320,7 @@ function buildAvailableActionsBullets(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
 	},
 ): string {
 	const bullets = [
@@ -357,6 +370,7 @@ function buildExampleActionsJson(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
 		maxActionsPerTurn: number;
 	},
 ): string {
@@ -377,6 +391,7 @@ function buildShellActionRules(
 	context: {
 		shellAccess: ShellAccess;
 		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
 	},
 ): string {
 	if (context.shellAccess === "read_write") {
@@ -388,6 +403,31 @@ function buildShellActionRules(
 
 	return loadPromptFile(
 		"prompts/partials/shell-action-rules/read-only.md",
+		repoRoot,
+	).trim();
+}
+
+function buildPostPersistCompletionRules(
+	repoRoot: string,
+	context: {
+		shellAccess: ShellAccess;
+		allowPersistWork: boolean;
+		requirePostPersistVerification: boolean;
+	},
+): string {
+	if (!context.allowPersistWork) {
+		return "";
+	}
+
+	if (context.requirePostPersistVerification) {
+		return loadPromptFile(
+			"prompts/partials/post-persist-completion-rules/require-verification.md",
+			repoRoot,
+		).trim();
+	}
+
+	return loadPromptFile(
+		"prompts/partials/post-persist-completion-rules/handoff-to-overseer.md",
 		repoRoot,
 	).trim();
 }

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -64,6 +64,7 @@ export class TaskPersona {
 			modelName: this.bot.llm.model,
 			shellAccess: this.bot.shellAccess,
 			maxActionsPerTurn: this.bot.maxActionsPerTurn,
+			requirePostPersistVerification: this.bot.requirePostPersistVerification,
 			promptDefinition: {
 				botId: this.bot.id,
 				displayName: this.bot.displayName,

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -502,6 +502,84 @@ describe("AgentRunner", () => {
 		);
 	});
 
+	it("allows done after persist_work without read-only verification when configured", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the file.", "Persist the file.", "Return control."],
+				next_step: "Edit the file.",
+				actions: [{ type: "run_shell", command: "printf ok >> file.txt" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the file.", "Persist the file.", "Return control."],
+				next_step: "Persist the file.",
+				actions: [{ type: "persist_work" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Edit the file.", "Persist the file.", "Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Persisted the change and handed back to Overseer.",
+			}),
+		];
+
+		const sentMessages: string[] = [];
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "ok",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		const result = await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			6,
+			{
+				shellAccess: "read_write",
+				maxActionsPerTurn: 1,
+				requirePostPersistVerification: false,
+				persistWork: async () => ({
+					ok: true,
+					branch: "bot/issue-35",
+					commit_sha: "abc123",
+					changed_files: ["file.txt"],
+					message: "Persisted successfully.",
+				}),
+			},
+		);
+
+		expect(result.finalResponse).toBe(
+			"Persisted the change and handed back to Overseer.",
+		);
+		expect(
+			sentMessages.some((message) =>
+				message.includes("Persistence succeeded. Run a read-only verification"),
+			),
+		).toBe(false);
+	});
+
 	it("repairs repeated no-progress cycles and aborts after continued repetition", async () => {
 		const repeatingResponse = JSON.stringify({
 			version: AGENT_PROTOCOL_VERSION,

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -30,6 +30,7 @@ export interface AgentRunnerOptions {
 	modelName?: string;
 	shellAccess?: ShellExecutionMode;
 	maxActionsPerTurn?: number;
+	requirePostPersistVerification?: boolean;
 	promptDefinition?: {
 		botId: string;
 		displayName: string;
@@ -196,7 +197,10 @@ export class AgentRunner {
 					currentMessage = buildProtocolRepairMessage(error, responseText);
 					continue;
 				}
-				const doneValidationError = this.validateDoneResponse(progressState);
+				const doneValidationError = this.validateDoneResponse(
+					progressState,
+					options.requirePostPersistVerification ?? true,
+				);
 				if (doneValidationError) {
 					logTrace("agent.iteration.protocolError", {
 						iteration,
@@ -268,7 +272,10 @@ export class AgentRunner {
 				continue;
 			}
 
-			const reminder = this.buildProgressReminder(progressState);
+			const reminder = this.buildProgressReminder(
+				progressState,
+				options.requirePostPersistVerification ?? true,
+			);
 			currentMessage = buildContinuationMessage({
 				originalTask,
 				iteration,
@@ -432,7 +439,10 @@ export class AgentRunner {
 		}
 	}
 
-	private validateDoneResponse(state: RunnerProgressState): string | null {
+	private validateDoneResponse(
+		state: RunnerProgressState,
+		requirePostPersistVerification: boolean,
+	): string | null {
 		if (!state.usedRunShell) {
 			return null;
 		}
@@ -441,7 +451,7 @@ export class AgentRunner {
 			return 'task_status "done" is not allowed after a successful run_shell action until persist_work succeeds';
 		}
 
-		if (!state.verifiedAfterPersist) {
+		if (requirePostPersistVerification && !state.verifiedAfterPersist) {
 			return 'task_status "done" is not allowed after persist_work until you verify the persisted branch state with run_ro_shell';
 		}
 
@@ -450,6 +460,7 @@ export class AgentRunner {
 
 	private buildProgressReminder(
 		state: RunnerProgressState,
+		requirePostPersistVerification: boolean,
 	): string | undefined {
 		if (!state.usedRunShell) {
 			return undefined;
@@ -457,7 +468,7 @@ export class AgentRunner {
 		if (!state.persistSucceededAfterWrite) {
 			return "You have used run_shell successfully in this task. Do not finish until persist_work succeeds.";
 		}
-		if (!state.verifiedAfterPersist) {
+		if (requirePostPersistVerification && !state.verifiedAfterPersist) {
 			return "Persistence succeeded. Run a read-only verification against the persisted branch or file contents before finishing.";
 		}
 		return undefined;


### PR DESCRIPTION
## What changed

This changes `developer-tester` so it no longer has to perform post-persist remote verification itself.

The new contract is:
- make the edit
- run the local verification for the increment
- call `persist_work`
- hand back to Overseer for review

Implementation details:
- add a bot-level `require_post_persist_verification` flag in `bots.json`
- set that flag to `false` for `developer-tester`
- thread the flag through bot loading and task persona runner options
- make `AgentRunner` require post-persist `run_ro_shell` verification only when that flag is enabled
- update the persisting and developer-tester prompts to reflect the new handoff boundary
- add tests covering the relaxed `developer-tester` completion behavior

## Why

`developer-tester` was getting stuck after successful local edits and successful `persist_work`, then burning iterations on remote verification steps that Overseer can handle more reliably.

## Validation

- `npx tsc --noEmit`
- `npx biome check src/`
- `npm test`
