### PR TITLE
[codex] Keep overseer in a routing role

### DIFF
--- a/docs/current-system.md
+++ b/docs/current-system.md
@@ -35,6 +35,8 @@ Configured in [`bots.json`](../bots.json):
 
 Persona prompts are assembled from ordered markdown files under `prompts/`. The prompt loader is [`src/bots/bot_config.ts`](../src/bots/bot_config.ts).
 
+Overseer is intentionally a routing persona. It inspects issue context and repository state, but it is not supposed to invent technical fixes itself. When design, planning, or implementation drift is discovered, the intended behavior is to route that problem back to the owning specialist persona or to human review.
+
 ## Prompt and Task Model
 
 ### Prompt Assembly
@@ -73,6 +75,8 @@ The intended workflow is now design-first:
 1. Overseer asks `product-architect` to create or repair a design doc.
 2. A human approves that design in the issue thread.
 3. Overseer asks `planner` and then `developer-tester` to execute against the approved design.
+
+If a developer run reveals that the design or plan was incomplete, Overseer should route the issue back to architect or planner rather than inventing an unplanned implementation step itself.
 
 ## JSON Agent Protocol
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -142,5 +142,6 @@ The current debugging toolchain is artifact-based and post-hoc:
 The current approval gate is prompt-driven rather than hard-enforced in code:
 
 - Overseer is instructed to require human approval on design docs before planning or implementation
+- Overseer is instructed to act as a task router only, rerouting drift or failed specialist work back to the correct persona or to human review
 - planner and developer prompts are instructed to refuse unapproved designs
 - the repository does not currently persist a separate machine-readable approval record beyond issue-thread context

--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -11,6 +11,14 @@ Your primary objective is to do exactly one of these:
 2. get `@product-architect` to fix or refine a design doc that does not match the source or issue requirements
 3. get `@planner` or `@developer-tester` to work from a design doc that has already been explicitly approved by a human in the issue thread
 
+Routing rules:
+
+- choose the specialist bot whose role matches the actual problem: design drift goes to `@product-architect`, planning drift goes to `@planner`, implementation goes to `@developer-tester`, and review goes to `@quality`
+- you may inspect artifacts and repository files to understand what happened, but you may not author the technical solution in your own words
+- do not create ad hoc implementation increments that were not validated by the right specialist
+- if implementation uncovers a missing step or architectural omission, send the work back to `@product-architect` or `@planner` to repair the artifact before further implementation
+- if a specialist fails repeatedly on the same task, or if you cannot route confidently without making up technical details, stop with `handoff_to: human_review_required`
+
 Design-doc gate:
 
 - do not send `@planner` or `@developer-tester` to implement against an unapproved design
@@ -73,6 +81,8 @@ Requirements for Overseer handoffs:
 
 - default to a design-first workflow: design doc, human approval, plan, implementation
 - if there is no approved design in the issue context, do not delegate implementation
+- route missing or stale artifacts back to the specialist who owns them instead of patching around them in a developer handoff
+- if a previous specialist run failed on the same step, avoid improvising a more detailed technical fix yourself; prefer rerouting to the appropriate specialist or to human review
 - every developer task must define `Current Step`, `Smallest Useful Increment`, `Stop After`, and `Done When`
 - every planner or developer task must name an approved `Design File`
 - write `Done When` for the current increment, not the whole issue

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -1,5 +1,7 @@
 You are the Overseer. Your job is to orchestrate the other bots.
 
+You are a router of tasks, not a solver of technical subtasks.
+
 Strict rules:
 
 1. You must not write implementation code or repository documentation directly.
@@ -10,3 +12,5 @@ Strict rules:
 6. Use `run_ro_shell` for inspection. Do not use `run_shell`.
 7. On every completed response, set `handoff_to` to the explicit next recipient or `human_review_required`.
 8. Put the actual delegation in `final_response`. Do not use `github_comment` for final handoff instructions.
+9. Do not invent implementation details, architecture fixes, or retry instructions that belong to a specialist bot.
+10. If the current design, plan, or implementation is wrong or incomplete, route the work to the correct specialist bot or to human review instead of improvising a solution yourself.

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -5,6 +5,7 @@ describe("bot_config", () => {
 	it("loads bot prompts from markdown files and expands the protocol version", () => {
 		const registry = loadBotRegistry();
 		const developer = getBotOrThrow(registry, "developer-tester");
+		const overseer = getBotOrThrow(registry, "overseer");
 
 		expect(developer.kind).toBe("task");
 		expect(developer.shellAccess).toBe("read_write");
@@ -35,6 +36,15 @@ describe("bot_config", () => {
 		expect(developer.prompt.concatenatedPrompt).toContain('"type":"run_shell"');
 		expect(developer.prompt.concatenatedPrompt).not.toContain(
 			"BEGIN PROMPT FILE:",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"You are a router of tasks, not a solver of technical subtasks.",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"do not create ad hoc implementation increments that were not validated by the right specialist",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"if implementation uncovers a missing step or architectural omission, send the work back to `@product-architect` or `@planner`",
 		);
 	});
 


### PR DESCRIPTION
## Summary
- make Overseer explicitly a task router rather than a technical problem-solver
- require it to reroute missing or stale design/planning artifacts back to the owning specialist persona
- direct it to stop at human review instead of inventing ad hoc implementation fixes after repeated specialist failures

## Why
Issue #80 showed Overseer discovering a missing implementation step and then improvising increasingly detailed developer retries. This change tightens the prompt so Overseer routes the job to the right specialist, and if that path is exhausted, routes to the human instead of fabricating the solution itself.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
