### PR TITLE
[codex] Improve harness editing and continuation flow

### DIFF
--- a/bots.json
+++ b/bots.json
@@ -1,89 +1,85 @@
 {
-  "defaults": {
-    "llm": {
-      "provider": "gemini",
-      "model": "gemini-3.1-pro-preview"
-    },
-    "prompt_files": [
-      "prompts/shared/base.md",
-      "prompts/shared/github-actions.md",
-      "prompts/shared/agent-protocol.md"
-    ],
-    "max_iterations": 20,
-    "max_actions_per_turn": 2
-  },
-  "bots": [
-    {
-      "id": "overseer",
-      "display_name": "Overseer",
-      "kind": "overseer",
-      "shell_access": "read_only",
-      "allow_persist_work": false,
-      "max_iterations": 12,
-      "max_actions_per_turn": 2,
-      "prompt_files": [
-        "prompts/shared/overseer-core.md",
-        "prompts/overseer.md"
-      ]
-    },
-    {
-      "id": "product-architect",
-      "display_name": "Product/Architect",
-      "kind": "task",
-      "shell_access": "read_write",
-      "allow_persist_work": true,
-      "max_iterations": 10,
-      "max_actions_per_turn": 1,
-      "prompt_files": [
-        "prompts/shared/task-agent.md",
-        "prompts/shared/persisting-agent.md",
-        "prompts/product-architect.md"
-      ]
-    },
-    {
-      "id": "planner",
-      "display_name": "Planner",
-      "kind": "task",
-      "shell_access": "read_write",
-      "allow_persist_work": true,
-      "max_iterations": 10,
-      "max_actions_per_turn": 1,
-      "prompt_files": [
-        "prompts/shared/task-agent.md",
-        "prompts/shared/persisting-agent.md",
-        "prompts/planner.md"
-      ]
-    },
-    {
-      "id": "developer-tester",
-      "display_name": "Developer/Tester",
-      "kind": "task",
-      "shell_access": "read_write",
-      "allow_persist_work": true,
-      "require_post_persist_verification": false,
-      "max_iterations": 50,
-      "max_actions_per_turn": 1,
-      "prompt_files": [
-        "prompts/shared/task-agent.md",
-        "prompts/shared/persisting-agent.md",
-        "prompts/shared/developer-guidance.md",
-        "prompts/developer-tester.md"
-      ]
-    },
-    {
-      "id": "quality",
-      "display_name": "Quality",
-      "kind": "task",
-      "shell_access": "read_only",
-      "allow_persist_work": false,
-      "max_iterations": 8,
-      "max_actions_per_turn": 1,
-      "prompt_files": [
-        "prompts/shared/task-agent.md",
-        "prompts/shared/read-only-agent.md",
-        "prompts/quality.md"
-      ]
-    }
-
-  ]
+	"defaults": {
+		"llm": {
+			"provider": "gemini",
+			"model": "gemini-3.1-pro-preview"
+		},
+		"prompt_files": [
+			"prompts/shared/base.md",
+			"prompts/shared/github-actions.md",
+			"prompts/shared/agent-protocol.md"
+		],
+		"max_iterations": 20,
+		"max_actions_per_turn": 2
+	},
+	"bots": [
+		{
+			"id": "overseer",
+			"display_name": "Overseer",
+			"kind": "overseer",
+			"shell_access": "read_only",
+			"allow_persist_work": false,
+			"max_iterations": 12,
+			"max_actions_per_turn": 2,
+			"prompt_files": ["prompts/shared/overseer-core.md", "prompts/overseer.md"]
+		},
+		{
+			"id": "product-architect",
+			"display_name": "Product/Architect",
+			"kind": "task",
+			"shell_access": "read_write",
+			"allow_persist_work": true,
+			"max_iterations": 10,
+			"max_actions_per_turn": 1,
+			"prompt_files": [
+				"prompts/shared/task-agent.md",
+				"prompts/shared/persisting-agent.md",
+				"prompts/product-architect.md"
+			]
+		},
+		{
+			"id": "planner",
+			"display_name": "Planner",
+			"kind": "task",
+			"shell_access": "read_write",
+			"allow_persist_work": true,
+			"max_iterations": 10,
+			"max_actions_per_turn": 1,
+			"prompt_files": [
+				"prompts/shared/task-agent.md",
+				"prompts/shared/persisting-agent.md",
+				"prompts/planner.md"
+			]
+		},
+		{
+			"id": "developer-tester",
+			"display_name": "Developer/Tester",
+			"kind": "task",
+			"shell_access": "read_write",
+			"allow_persist_work": true,
+			"require_post_persist_verification": false,
+			"max_iterations": 50,
+			"max_actions_per_turn": 2,
+			"prompt_files": [
+				"prompts/shared/task-agent.md",
+				"prompts/shared/persisting-agent.md",
+				"prompts/shared/developer-guidance.md",
+				"prompts/developer-tester.md"
+			]
+		},
+		{
+			"id": "quality",
+			"display_name": "Quality",
+			"kind": "task",
+			"shell_access": "read_only",
+			"allow_persist_work": false,
+			"max_iterations": 8,
+			"max_actions_per_turn": 1,
+			"prompt_files": [
+				"prompts/shared/task-agent.md",
+				"prompts/shared/read-only-agent.md",
+				"prompts/quality.md"
+			]
+		}
+	]
 }

--- a/prompts/developer-tester.md
+++ b/prompts/developer-tester.md
@@ -14,9 +14,10 @@ Developer/Tester guardrails:
 
 - if `Design Approval Status` is not `approved`, stop and hand back to Overseer instead of implementing
 - treat the approved design doc as the source of truth for the increment unless the repository proves the design is stale, in which case stop and report the drift
-- default to exactly one action per turn
+- prefer the shortest useful turn shape, including inspect+edit or edit+verification when that will complete the immediate step faster
 - do not try to finish the entire plan in one run unless the task packet explicitly says this increment is final
 - after understanding the planner's step, bias toward making a small code change rather than gathering more context
+- prefer `replace_in_file` for precise edits to existing files instead of inventing shell patch scripts
 - do not perform extra remote-branch verification after `persist_work`; Overseer is responsible for reviewing the persisted result
 - once you have completed one meaningful increment, stop and return control instead of rolling into the next likely step
 - do not spend multiple turns re-listing directories or rereading the same file without a reason

--- a/prompts/partials/action-count-rules.md
+++ b/prompts/partials/action-count-rules.md
@@ -1,3 +1,3 @@
 - You may return at most {{MAX_ACTIONS_PER_TURN}} {{ACTION_WORD}} in a single response.
-- Prefer exactly one action per turn unless bundling is clearly necessary to complete one immediate step.
+- Prefer one focused action per turn, but bundle inspect+edit or edit+verification when that is the shortest path to one immediate step.
 - Do not repeat the same action on consecutive turns unless the repository state changed or your previous output explains why the retry is materially different.

--- a/prompts/partials/available-actions/replace-in-file-disabled.md
+++ b/prompts/partials/available-actions/replace-in-file-disabled.md
@@ -1,0 +1,1 @@
+- `replace_in_file` is not available to this bot. Stay inside `run_ro_shell` and do not attempt repository writes.

--- a/prompts/partials/available-actions/replace-in-file-enabled.md
+++ b/prompts/partials/available-actions/replace-in-file-enabled.md
@@ -1,0 +1,1 @@
+- `{"type":"replace_in_file","path":"...","old_string":"...","new_string":"..."}` for precise in-repo text edits without writing ad hoc patch scripts. If `old_string` appears multiple times, either make it more specific or set `"replace_all": true`.

--- a/prompts/partials/example-actions/read-only.json
+++ b/prompts/partials/example-actions/read-only.json
@@ -1,10 +1,10 @@
 [
-  {
-    "type": "run_ro_shell",
-    "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
-  },
-  {
-    "type": "run_ro_shell",
-    "command": "cat docs/plans/current-plan.md"
-  }
+	{
+		"type": "run_ro_shell",
+		"command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
+	},
+	{
+		"type": "run_ro_shell",
+		"command": "cat docs/plans/current-plan.md"
+	}
 ]

--- a/prompts/partials/example-actions/read-write-2.json
+++ b/prompts/partials/example-actions/read-write-2.json
@@ -1,0 +1,12 @@
+[
+	{
+		"type": "run_ro_shell",
+		"command": "sed -n '1,200p' docs/plans/current-plan.md"
+	},
+	{
+		"type": "replace_in_file",
+		"path": "src/example.ts",
+		"old_string": "const enabled = false;",
+		"new_string": "const enabled = true;"
+	}
+]

--- a/prompts/partials/example-actions/read-write.json
+++ b/prompts/partials/example-actions/read-write.json
@@ -1,10 +1,10 @@
 [
-  {
-    "type": "run_ro_shell",
-    "command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
-  },
-  {
-    "type": "run_shell",
-    "command": "cat docs/plans/current-plan.md"
-  }
+	{
+		"type": "run_ro_shell",
+		"command": "[ -f WORKFLOW.md ] && cat WORKFLOW.md || true"
+	},
+	{
+		"type": "run_shell",
+		"command": "cat docs/plans/current-plan.md"
+	}
 ]

--- a/prompts/partials/shell-action-rules/read-write.md
+++ b/prompts/partials/shell-action-rules/read-write.md
@@ -1,3 +1,5 @@
 - `run_ro_shell` is the default choice for inspection and verification.
+- Prefer `replace_in_file` for precise text edits to existing files.
 - Use `run_shell` only when you intentionally need to modify repository files or run write-dependent project tooling.
+- Do not create temporary patch scripts when `replace_in_file` can express the edit directly.
 - If the environment is missing a tool you need, edit `flake.nix` and then continue using the shell actions above.

--- a/prompts/runtime/continuation.md
+++ b/prompts/runtime/continuation.md
@@ -3,14 +3,17 @@ ORIGINAL TASK:
 
 CURRENT ITERATION: {{ITERATION}}
 
-MOST RECENT STRUCTURED RESPONSE:
-{{PREVIOUS_RESPONSE_JSON}}
+MOST RECENT PLAN:
+{{PREVIOUS_PLAN}}
 
-{{PREVIOUS_GITHUB_COMMENT_SECTION}}LATEST ACTION OUTPUT:
-{{ACTION_OUTPUT}}
+MOST RECENT NEXT STEP:
+{{PREVIOUS_NEXT_STEP}}
+
+{{PREVIOUS_GITHUB_COMMENT_SECTION}}MOST RECENT ACTION RESULTS:
+{{ACTION_RESULT_SUMMARY}}
 
 {{REMINDER_SECTION}}Continue the same assigned increment. Do not restart or expand the assignment.
-Use the original task packet and your most recent structured response to decide the next immediate step.
+Use the original task packet, your current plan, and the most recent action results to decide the next immediate step.
 If the current increment is complete, return control with a concise progress update instead of starting the next increment.
 Continue the task using protocol "{{AGENT_PROTOCOL_VERSION}}".
 Return exactly one JSON object.

--- a/prompts/runtime/loop-repair.md
+++ b/prompts/runtime/loop-repair.md
@@ -6,11 +6,14 @@ ORIGINAL TASK:
 
 CURRENT ITERATION: {{ITERATION}}
 
-MOST RECENT STRUCTURED RESPONSE:
-{{PREVIOUS_RESPONSE_JSON}}
+MOST RECENT PLAN:
+{{PREVIOUS_PLAN}}
 
-LATEST ACTION OUTPUT:
-{{ACTION_OUTPUT}}
+MOST RECENT NEXT STEP:
+{{PREVIOUS_NEXT_STEP}}
+
+MOST RECENT ACTION RESULTS:
+{{ACTION_RESULT_SUMMARY}}
 
 Do not repeat the same action again unless the repository state has changed.
 Revise the plan and choose a materially different next step, or finish with a concise blocker summary if the task cannot progress safely.

--- a/prompts/shared/agent-protocol.md
+++ b/prompts/shared/agent-protocol.md
@@ -43,7 +43,7 @@ Example in-progress response object:
     "Inspect the relevant plan and implementation files.",
     "Make the minimal code change required by the task.",
     "Run targeted verification.",
-    "Persist the work and confirm it exists on the issue branch."
+    "Persist the work and hand control back."
   ],
   "next_step": "Read WORKFLOW.md and the referenced plan file before changing code.",
   "actions": {{IN_PROGRESS_EXAMPLE_ACTIONS}},

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -11,7 +11,7 @@ describe("bot_config", () => {
 		expect(developer.shellAccess).toBe("read_write");
 		expect(developer.allowPersistWork).toBe(true);
 		expect(developer.requirePostPersistVerification).toBe(false);
-		expect(developer.maxActionsPerTurn).toBe(1);
+		expect(developer.maxActionsPerTurn).toBe(2);
 		expect(developer.prompt.promptFiles).toContain(
 			"prompts/shared/agent-protocol.md",
 		);
@@ -31,7 +31,10 @@ describe("bot_config", () => {
 			'"type":"run_ro_shell"',
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain(
-			"You may return at most 1 action in a single response.",
+			"You may return at most 2 actions in a single response.",
+		);
+		expect(developer.prompt.concatenatedPrompt).toContain(
+			'"type":"replace_in_file"',
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain('"type":"run_shell"');
 		expect(developer.prompt.concatenatedPrompt).not.toContain(

--- a/src/bots/bot_config.ts
+++ b/src/bots/bot_config.ts
@@ -333,11 +333,23 @@ function buildAvailableActionsBullets(
 	if (context.shellAccess === "read_write") {
 		bullets.push(
 			loadPromptFile(
+				"prompts/partials/available-actions/replace-in-file-enabled.md",
+				repoRoot,
+			).trim(),
+		);
+		bullets.push(
+			loadPromptFile(
 				"prompts/partials/available-actions/run-shell-enabled.md",
 				repoRoot,
 			).trim(),
 		);
 	} else {
+		bullets.push(
+			loadPromptFile(
+				"prompts/partials/available-actions/replace-in-file-disabled.md",
+				repoRoot,
+			).trim(),
+		);
 		bullets.push(
 			loadPromptFile(
 				"prompts/partials/available-actions/run-shell-disabled.md",
@@ -376,7 +388,9 @@ function buildExampleActionsJson(
 ): string {
 	const examplePath =
 		context.shellAccess === "read_write"
-			? "prompts/partials/example-actions/read-write.json"
+			? context.maxActionsPerTurn >= 2
+				? "prompts/partials/example-actions/read-write-2.json"
+				: "prompts/partials/example-actions/read-write.json"
 			: "prompts/partials/example-actions/read-only.json";
 	const actions = JSON.parse(loadPromptFile(examplePath, repoRoot)) as Array<{
 		type: string;

--- a/src/scripts/inspect_bots.test.ts
+++ b/src/scripts/inspect_bots.test.ts
@@ -25,7 +25,7 @@ describe("inspect_bots", () => {
 
 		expect(markdown).toContain("# Developer/Tester");
 		expect(markdown).toContain("Shell Access: `read_write`");
-		expect(markdown).toContain("Max Actions Per Turn: 1");
+		expect(markdown).toContain("Max Actions Per Turn: 2");
 		expect(markdown).toContain("## Prompt Files");
 		expect(markdown).toContain("`prompts/shared/developer-guidance.md`");
 		expect(markdown).toContain("## Concatenated Prompt");

--- a/src/utils/agent_protocol.test.ts
+++ b/src/utils/agent_protocol.test.ts
@@ -86,6 +86,34 @@ I will comply.
 		expect(parsed.protocol.actions).toEqual([{ type: "persist_work" }]);
 	});
 
+	it("parses replace_in_file actions", () => {
+		const parsed = parseAgentProtocolResponse(
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Update the target file."],
+				next_step: "Update the target file.",
+				actions: [
+					{
+						type: "replace_in_file",
+						path: "src/example.ts",
+						old_string: "const enabled = false;",
+						new_string: "const enabled = true;",
+					},
+				],
+				task_status: "in_progress",
+			}),
+		);
+
+		expect(parsed.protocol.actions).toEqual([
+			{
+				type: "replace_in_file",
+				path: "src/example.ts",
+				old_string: "const enabled = false;",
+				new_string: "const enabled = true;",
+			},
+		]);
+	});
+
 	it("parses optional github_comment and plan fields", () => {
 		const parsed = parseAgentProtocolResponse(
 			JSON.stringify({
@@ -185,33 +213,28 @@ I will comply.
 		).toThrow(/plan/);
 	});
 
-	it("builds continuation messages that restate task and prior response", () => {
+	it("builds continuation messages with a compact task state summary", () => {
 		const message = buildContinuationMessage({
 			originalTask: "Developer Task:\nTask ID: issue-55",
 			iteration: 3,
-			previousResponseJson: JSON.stringify({
-				version: AGENT_PROTOCOL_VERSION,
-				plan: ["Read the plan", "Implement the change"],
-				next_step: "Read the plan",
-				actions: [
-					{ type: "run_ro_shell", command: "cat docs/plans/current.md" },
-				],
-				task_status: "in_progress",
-			}),
+			previousPlan: ["Read the plan", "Implement the change"],
+			previousNextStep: "Read the plan",
 			previousGithubComment: "Reading the plan before changing code.",
-			actionOutput:
-				"--- EXECUTING: cat docs/plans/current.md ---\nSTDOUT:\nPlan contents",
+			actionResultSummary:
+				"run_ro_shell `cat docs/plans/current.md` exited with code 0.\nstdout preview: Plan contents",
 		});
 
 		expect(message).toContain("ORIGINAL TASK:");
 		expect(message).toContain("Task ID: issue-55");
 		expect(message).toContain("CURRENT ITERATION: 3");
-		expect(message).toContain("MOST RECENT STRUCTURED RESPONSE:");
-		expect(message).toContain('"next_step":"Read the plan"');
+		expect(message).toContain("MOST RECENT PLAN:");
+		expect(message).toContain("- Read the plan");
+		expect(message).toContain("MOST RECENT NEXT STEP:");
+		expect(message).toContain("Read the plan");
 		expect(message).toContain("MOST RECENT GITHUB STATUS COMMENT:");
 		expect(message).toContain("Reading the plan before changing code.");
-		expect(message).toContain("LATEST ACTION OUTPUT:");
-		expect(message).toContain("Plan contents");
+		expect(message).toContain("MOST RECENT ACTION RESULTS:");
+		expect(message).toContain("stdout preview: Plan contents");
 		expect(message).toContain("Continue the same assigned increment.");
 		expect(message).toContain("return control with a concise progress update");
 		expect(message).toContain(

--- a/src/utils/agent_protocol.ts
+++ b/src/utils/agent_protocol.ts
@@ -23,6 +23,14 @@ export interface RunShellAction {
 	command: string;
 }
 
+export interface ReplaceInFileAction {
+	type: "replace_in_file";
+	path: string;
+	old_string: string;
+	new_string: string;
+	replace_all?: boolean;
+}
+
 export interface PersistWorkAction {
 	type: "persist_work";
 }
@@ -30,6 +38,7 @@ export interface PersistWorkAction {
 export type AgentAction =
 	| RunReadOnlyShellAction
 	| RunShellAction
+	| ReplaceInFileAction
 	| PersistWorkAction;
 
 export interface AgentProtocolResponse {
@@ -51,9 +60,10 @@ export interface ParsedAgentProtocolResponse {
 export interface ContinuationContext {
 	originalTask: string;
 	iteration: number;
-	previousResponseJson: string;
+	previousPlan: string[];
+	previousNextStep: string;
 	previousGithubComment?: string;
-	actionOutput: string;
+	actionResultSummary: string;
 	reminder?: string;
 }
 
@@ -71,9 +81,10 @@ export function buildProtocolRepairMessage(
 export function buildContinuationMessage({
 	originalTask,
 	iteration,
-	previousResponseJson,
+	previousPlan,
+	previousNextStep,
 	previousGithubComment,
-	actionOutput,
+	actionResultSummary,
 	reminder,
 }: ContinuationContext): string {
 	const previousGithubCommentSection = previousGithubComment
@@ -93,9 +104,10 @@ export function buildContinuationMessage({
 	return renderPromptFile("prompts/runtime/continuation.md", {
 		ORIGINAL_TASK: originalTask,
 		ITERATION: String(iteration),
-		PREVIOUS_RESPONSE_JSON: previousResponseJson,
+		PREVIOUS_PLAN: previousPlan.map((step) => `- ${step}`).join("\n"),
+		PREVIOUS_NEXT_STEP: previousNextStep,
 		PREVIOUS_GITHUB_COMMENT_SECTION: previousGithubCommentSection,
-		ACTION_OUTPUT: actionOutput,
+		ACTION_RESULT_SUMMARY: actionResultSummary,
 		REMINDER_SECTION: reminderSection,
 		AGENT_PROTOCOL_VERSION,
 	});
@@ -104,16 +116,18 @@ export function buildContinuationMessage({
 export function buildLoopRepairMessage(input: {
 	originalTask: string;
 	iteration: number;
-	previousResponseJson: string;
-	actionOutput: string;
+	previousPlan: string[];
+	previousNextStep: string;
+	actionResultSummary: string;
 	repeatedCycleCount: number;
 }): string {
 	return renderPromptFile("prompts/runtime/loop-repair.md", {
 		REPEATED_CYCLE_COUNT: String(input.repeatedCycleCount),
 		ORIGINAL_TASK: input.originalTask,
 		ITERATION: String(input.iteration),
-		PREVIOUS_RESPONSE_JSON: input.previousResponseJson,
-		ACTION_OUTPUT: input.actionOutput,
+		PREVIOUS_PLAN: input.previousPlan.map((step) => `- ${step}`).join("\n"),
+		PREVIOUS_NEXT_STEP: input.previousNextStep,
+		ACTION_RESULT_SUMMARY: input.actionResultSummary,
 		AGENT_PROTOCOL_VERSION,
 	});
 }
@@ -345,6 +359,27 @@ function parseAction(value: unknown, index: number): AgentAction {
 		};
 	}
 
+	if (type === "replace_in_file") {
+		return {
+			type: "replace_in_file",
+			path: requireNonEmptyString(record.path, `actions[${index}].path`),
+			old_string: requireNonEmptyString(
+				record.old_string,
+				`actions[${index}].old_string`,
+			),
+			new_string:
+				typeof record.new_string === "string"
+					? record.new_string
+					: (() => {
+							throw new Error(`actions[${index}].new_string must be a string`);
+						})(),
+			replace_all: parseOptionalBoolean(
+				record.replace_all,
+				`actions[${index}].replace_all`,
+			),
+		};
+	}
+
 	if (type === "persist_work") {
 		return {
 			type: "persist_work",
@@ -352,7 +387,7 @@ function parseAction(value: unknown, index: number): AgentAction {
 	}
 
 	throw new Error(
-		`actions[${index}].type must be "run_ro_shell", "run_shell", or "persist_work"`,
+		`actions[${index}].type must be "run_ro_shell", "run_shell", "replace_in_file", or "persist_work"`,
 	);
 }
 
@@ -367,4 +402,17 @@ function parseRequiredPlan(value: unknown): string[] {
 	return value.map((entry, index) =>
 		requireNonEmptyString(entry, `plan[${index}]`),
 	);
+}
+
+function parseOptionalBoolean(
+	value: unknown,
+	fieldName: string,
+): boolean | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	if (typeof value !== "boolean") {
+		throw new Error(`${fieldName} must be a boolean`);
+	}
+	return value;
 }

--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -94,13 +94,13 @@ describe("AgentRunner", () => {
 		expect(sentMessages[1]).toContain("ORIGINAL TASK:");
 		expect(sentMessages[1]).toContain("Initial message");
 		expect(sentMessages[1]).toContain("CURRENT ITERATION: 1");
-		expect(sentMessages[1]).toContain("MOST RECENT STRUCTURED RESPONSE:");
-		expect(sentMessages[1]).toContain(
-			'"next_step":"Inspect the repository root."',
-		);
-		expect(sentMessages[1]).toContain("LATEST ACTION OUTPUT:");
-		expect(sentMessages[1]).toContain("hello");
-		expect(sentMessages[1]).toContain("world");
+		expect(sentMessages[1]).toContain("MOST RECENT PLAN:");
+		expect(sentMessages[1]).toContain("- Inspect the repository root.");
+		expect(sentMessages[1]).toContain("MOST RECENT NEXT STEP:");
+		expect(sentMessages[1]).toContain("Inspect the repository root.");
+		expect(sentMessages[1]).toContain("MOST RECENT ACTION RESULTS:");
+		expect(sentMessages[1]).toContain("stdout preview: hello");
+		expect(sentMessages[1]).toContain("stdout preview: world");
 	});
 
 	it("executes persist_work actions through the injected callback", async () => {
@@ -270,6 +270,96 @@ describe("AgentRunner", () => {
 
 		expect(result.log).toContain("run_shell_not_available");
 		expect(result.finalResponse).toContain("Returned control");
+	});
+
+	it("executes replace_in_file actions directly in the repository", async () => {
+		const repoRoot = process.cwd();
+		const tempDir = mkdtempSync(
+			join(repoRoot, ".tmp-overseer-replace-in-file-"),
+		);
+		writeFileSync(join(tempDir, "target.ts"), "const enabled = false;\n");
+		const relativePath = `${tempDir.slice(repoRoot.length + 1)}/target.ts`;
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Update the file.", "Persist the change.", "Return control."],
+				next_step: "Update the file.",
+				actions: [
+					{
+						type: "replace_in_file",
+						path: relativePath,
+						old_string: "const enabled = false;",
+						new_string: "const enabled = true;",
+					},
+				],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Update the file.", "Persist the change.", "Return control."],
+				next_step: "Persist the change.",
+				actions: [{ type: "persist_work" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Update the file.", "Persist the change.", "Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Updated and persisted the file.",
+			}),
+		];
+
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage() {
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		try {
+			const result = await runner.runAutonomousLoop(
+				gemini as never,
+				"System instruction",
+				"Initial message",
+				6,
+				{
+					shellAccess: "read_write",
+					maxActionsPerTurn: 1,
+					requirePostPersistVerification: false,
+					persistWork: async () => ({
+						ok: true,
+						branch: "bot/issue-35",
+						commit_sha: "abc123",
+						changed_files: [relativePath],
+						message: "Persisted successfully.",
+					}),
+				},
+			);
+
+			expect(result.finalResponse).toBe("Updated and persisted the file.");
+			expect(result.log).toContain('"replacements": 1');
+			expect(readFileSync(join(tempDir, "target.ts"), "utf8")).toContain(
+				"const enabled = true;",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("requires a structured handoff when configured", async () => {
@@ -578,6 +668,79 @@ describe("AgentRunner", () => {
 				message.includes("Persistence succeeded. Run a read-only verification"),
 			),
 		).toBe(false);
+	});
+
+	it("nudges stalled read-only inspection toward action or a blocker", async () => {
+		const responses = [
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect the plan.", "Implement the change."],
+				next_step: "Inspect the plan.",
+				actions: [
+					{ type: "run_ro_shell", command: "cat docs/plans/current.md" },
+				],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect the plan.", "Implement the change."],
+				next_step: "Inspect the target file.",
+				actions: [
+					{ type: "run_ro_shell", command: "sed -n '1,80p' src/file.ts" },
+				],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Return control."],
+				next_step: "Return control.",
+				actions: [],
+				task_status: "done",
+				final_response: "Blocked on missing implementation detail.",
+			}),
+		];
+
+		const sentMessages: string[] = [];
+		const gemini = {
+			startChat() {
+				return {
+					async sendMessage(message: string) {
+						sentMessages.push(message);
+						const next = responses.shift();
+						if (!next) {
+							throw new Error("No more responses queued");
+						}
+						return { text: next, response: { text: () => next } };
+					},
+				};
+			},
+		};
+
+		const runner = new AgentRunner(
+			makeFakeShell(async () => ({
+				stdout: "ok",
+				stderr: "",
+				exitCode: 0,
+			})),
+		);
+		await runner.runAutonomousLoop(
+			gemini as never,
+			"System instruction",
+			"Initial message",
+			5,
+			{
+				shellAccess: "read_only",
+				maxActionsPerTurn: 1,
+			},
+		);
+
+		expect(
+			sentMessages.some((message) =>
+				message.includes(
+					"consecutive turns on read-only inspection without editing",
+				),
+			),
+		).toBe(true);
 	});
 
 	it("repairs repeated no-progress cycles and aborts after continued repetition", async () => {

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Content } from "@google/generative-ai";
 import {
@@ -56,23 +56,27 @@ export interface AgentRunnerOptions {
 interface ExecutedActionRecord {
 	type: ParsedAgentProtocolResponse["protocol"]["actions"][number]["type"];
 	command?: string;
+	path?: string;
 	exitCode?: number;
 	ok?: boolean;
 	persistResult?: PersistWorkResult;
+	message?: string;
 }
 
 interface ActionExecutionResult {
 	output: string;
+	summary: string;
 	executedActions: ExecutedActionRecord[];
 }
 
 interface RunnerProgressState {
-	usedRunShell: boolean;
+	usedWriteAction: boolean;
 	persistSucceededAfterWrite: boolean;
 	verifiedAfterPersist: boolean;
 	lastLoopFingerprint?: string;
 	repeatedCycleCount: number;
 	loopRepairsIssued: number;
+	consecutiveReadOnlyTurnsWithoutWrite: number;
 }
 
 export class AgentRunner {
@@ -115,11 +119,12 @@ export class AgentRunner {
 		let currentMessage = initialMessage;
 		let iteration = 0;
 		const progressState: RunnerProgressState = {
-			usedRunShell: false,
+			usedWriteAction: false,
 			persistSucceededAfterWrite: false,
 			verifiedAfterPersist: false,
 			repeatedCycleCount: 0,
 			loopRepairsIssued: 0,
+			consecutiveReadOnlyTurnsWithoutWrite: 0,
 		};
 
 		while (iteration < maxIterations) {
@@ -225,12 +230,14 @@ export class AgentRunner {
 			);
 			this.updateProgressState(progressState, actionExecution.executedActions);
 			const actionOutput = actionExecution.output;
+			const actionSummary = actionExecution.summary;
 			logTrace("agent.iteration.action", {
 				iteration,
 				actionTypes: parsedResponse.protocol.actions.map(
 					(action) => action.type,
 				),
 				actionOutput: textStats(actionOutput),
+				actionSummary: textStats(actionSummary),
 			});
 			this.log(`ACTION OUTPUT: ${actionOutput}\n`);
 
@@ -265,8 +272,9 @@ export class AgentRunner {
 				currentMessage = buildLoopRepairMessage({
 					originalTask,
 					iteration,
-					previousResponseJson: parsedResponse.rawJson,
-					actionOutput,
+					previousPlan: parsedResponse.protocol.plan,
+					previousNextStep: parsedResponse.protocol.next_step,
+					actionResultSummary: actionSummary,
 					repeatedCycleCount: progressState.repeatedCycleCount + 1,
 				});
 				continue;
@@ -279,9 +287,10 @@ export class AgentRunner {
 			currentMessage = buildContinuationMessage({
 				originalTask,
 				iteration,
-				previousResponseJson: parsedResponse.rawJson,
+				previousPlan: parsedResponse.protocol.plan,
+				previousNextStep: parsedResponse.protocol.next_step,
 				previousGithubComment: parsedResponse.protocol.github_comment,
-				actionOutput,
+				actionResultSummary: actionSummary,
 				reminder,
 			});
 		}
@@ -307,11 +316,13 @@ export class AgentRunner {
 		if (actions.length === 0) {
 			return {
 				output: "ERROR: No actions were supplied.",
+				summary: "No actions were supplied.",
 				executedActions: [],
 			};
 		}
 
 		const outputs: string[] = [];
+		const summaries: string[] = [];
 		const executedActions: ExecutedActionRecord[] = [];
 		const shellAccess = options.shellAccess ?? "read_write";
 
@@ -327,7 +338,11 @@ export class AgentRunner {
 					exitCode: result.exitCode,
 					ok: result.exitCode === 0,
 				});
-				outputs.push(this.formatShellOutput(action.command, result));
+				const formatted = this.formatShellOutput(action.command, result);
+				outputs.push(formatted);
+				summaries.push(
+					this.summarizeShellResult(action.command, result, "run_ro_shell"),
+				);
 				continue;
 			}
 
@@ -343,8 +358,13 @@ export class AgentRunner {
 						type: action.type,
 						command: action.command,
 						ok: false,
+						message: denial.message,
 					});
-					outputs.push(JSON.stringify(denial, null, 2));
+					const formatted = JSON.stringify(denial, null, 2);
+					outputs.push(formatted);
+					summaries.push(
+						`run_shell denied: ${denial.message} (error_code=${denial.error_code})`,
+					);
 					continue;
 				}
 
@@ -358,7 +378,51 @@ export class AgentRunner {
 					exitCode: result.exitCode,
 					ok: result.exitCode === 0,
 				});
-				outputs.push(this.formatShellOutput(action.command, result));
+				const formatted = this.formatShellOutput(action.command, result);
+				outputs.push(formatted);
+				summaries.push(
+					this.summarizeShellResult(action.command, result, "run_shell"),
+				);
+				continue;
+			}
+
+			if (action.type === "replace_in_file") {
+				if (shellAccess !== "read_write") {
+					const denial = {
+						ok: false,
+						error_code: "replace_in_file_not_available",
+						message:
+							'replace_in_file is not available for this persona. Use "run_ro_shell" instead.',
+						path: action.path,
+					};
+					executedActions.push({
+						type: action.type,
+						path: action.path,
+						ok: false,
+						message: denial.message,
+					});
+					const formatted = JSON.stringify(denial, null, 2);
+					outputs.push(formatted);
+					summaries.push(
+						`replace_in_file denied for ${action.path}: ${denial.message} (error_code=${denial.error_code})`,
+					);
+					continue;
+				}
+
+				const result = this.executeReplaceInFile(action);
+				executedActions.push({
+					type: action.type,
+					path: action.path,
+					ok: result.ok,
+					message: result.message,
+				});
+				const formatted = JSON.stringify(result, null, 2);
+				outputs.push(formatted);
+				summaries.push(
+					result.ok
+						? `replace_in_file updated ${action.path} (${result.replacements} replacement${result.replacements === 1 ? "" : "s"})`
+						: `replace_in_file failed for ${action.path}: ${result.message} (error_code=${result.error_code})`,
+				);
 				continue;
 			}
 
@@ -373,8 +437,13 @@ export class AgentRunner {
 					type: action.type,
 					ok: false,
 					persistResult: denial,
+					message: denial.message,
 				});
-				outputs.push(JSON.stringify(denial, null, 2));
+				const formatted = JSON.stringify(denial, null, 2);
+				outputs.push(formatted);
+				summaries.push(
+					`persist_work unavailable: ${denial.message} (error_code=${denial.error_code})`,
+				);
 				continue;
 			}
 
@@ -383,12 +452,16 @@ export class AgentRunner {
 				type: action.type,
 				ok: result.ok,
 				persistResult: result,
+				message: result.message,
 			});
-			outputs.push(JSON.stringify(result, null, 2));
+			const formatted = JSON.stringify(result, null, 2);
+			outputs.push(formatted);
+			summaries.push(this.summarizePersistResult(result));
 		}
 
 		return {
 			output: outputs.join("\n"),
+			summary: summaries.join("\n"),
 			executedActions,
 		};
 	}
@@ -412,16 +485,38 @@ export class AgentRunner {
 		state: RunnerProgressState,
 		executedActions: ExecutedActionRecord[],
 	): void {
+		const wroteThisTurn = executedActions.some(
+			(action) =>
+				(action.type === "run_shell" || action.type === "replace_in_file") &&
+				action.ok,
+		);
+		const usedOnlyReadOnlyActions =
+			executedActions.length > 0 &&
+			executedActions.every(
+				(action) => action.type === "run_ro_shell" && action.ok,
+			);
+
+		if (wroteThisTurn) {
+			state.consecutiveReadOnlyTurnsWithoutWrite = 0;
+		} else if (usedOnlyReadOnlyActions) {
+			state.consecutiveReadOnlyTurnsWithoutWrite += 1;
+		} else {
+			state.consecutiveReadOnlyTurnsWithoutWrite = 0;
+		}
+
 		for (const action of executedActions) {
-			if (action.type === "run_shell" && action.ok) {
-				state.usedRunShell = true;
+			if (
+				(action.type === "run_shell" || action.type === "replace_in_file") &&
+				action.ok
+			) {
+				state.usedWriteAction = true;
 				state.persistSucceededAfterWrite = false;
 				state.verifiedAfterPersist = false;
 				continue;
 			}
 
 			if (action.type === "persist_work") {
-				if (state.usedRunShell && action.persistResult?.ok) {
+				if (state.usedWriteAction && action.persistResult?.ok) {
 					state.persistSucceededAfterWrite = true;
 					state.verifiedAfterPersist = false;
 				}
@@ -431,7 +526,7 @@ export class AgentRunner {
 			if (
 				action.type === "run_ro_shell" &&
 				action.ok &&
-				state.usedRunShell &&
+				state.usedWriteAction &&
 				state.persistSucceededAfterWrite
 			) {
 				state.verifiedAfterPersist = true;
@@ -443,12 +538,12 @@ export class AgentRunner {
 		state: RunnerProgressState,
 		requirePostPersistVerification: boolean,
 	): string | null {
-		if (!state.usedRunShell) {
+		if (!state.usedWriteAction) {
 			return null;
 		}
 
 		if (!state.persistSucceededAfterWrite) {
-			return 'task_status "done" is not allowed after a successful run_shell action until persist_work succeeds';
+			return 'task_status "done" is not allowed after a successful repository write action until persist_work succeeds';
 		}
 
 		if (requirePostPersistVerification && !state.verifiedAfterPersist) {
@@ -462,11 +557,14 @@ export class AgentRunner {
 		state: RunnerProgressState,
 		requirePostPersistVerification: boolean,
 	): string | undefined {
-		if (!state.usedRunShell) {
+		if (!state.usedWriteAction) {
+			if (state.consecutiveReadOnlyTurnsWithoutWrite >= 2) {
+				return `You have already spent ${state.consecutiveReadOnlyTurnsWithoutWrite} consecutive turns on read-only inspection without editing. Your next turn should make a targeted edit, run a focused verification, or return a blocker instead of rereading broad context.`;
+			}
 			return undefined;
 		}
 		if (!state.persistSucceededAfterWrite) {
-			return "You have used run_shell successfully in this task. Do not finish until persist_work succeeds.";
+			return "You have already modified repository files in this task. Do not finish until persist_work succeeds.";
 		}
 		if (requirePostPersistVerification && !state.verifiedAfterPersist) {
 			return "Persistence succeeded. Run a read-only verification against the persisted branch or file contents before finishing.";
@@ -485,8 +583,10 @@ export class AgentRunner {
 			executedActions: executedActions.map((action) => ({
 				type: action.type,
 				command: action.command,
+				path: action.path,
 				exitCode: action.exitCode,
 				ok: action.ok,
+				message: action.message,
 				persistOk: action.persistResult?.ok,
 				persistErrorCode: action.persistResult?.error_code,
 				persistMessage: action.persistResult?.message,
@@ -544,6 +644,112 @@ export class AgentRunner {
 					],
 				},
 			],
+		};
+	}
+
+	private summarizeShellResult(
+		command: string,
+		result: Awaited<ReturnType<ShellService["executeCommand"]>>,
+		actionType: "run_ro_shell" | "run_shell",
+	): string {
+		const parts = [
+			`${actionType} \`${command}\` exited with code ${result.exitCode}.`,
+		];
+		const stdoutPreview = this.truncateForPrompt(result.stdout);
+		if (stdoutPreview) {
+			parts.push(`stdout preview: ${stdoutPreview}`);
+		}
+		const stderrPreview = this.truncateForPrompt(result.stderr);
+		if (stderrPreview) {
+			parts.push(`stderr preview: ${stderrPreview}`);
+		}
+		return parts.join("\n");
+	}
+
+	private summarizePersistResult(result: PersistWorkResult): string {
+		if (result.ok) {
+			const changedFiles =
+				result.changed_files && result.changed_files.length > 0
+					? result.changed_files.join(", ")
+					: "none reported";
+			return `persist_work succeeded on branch ${result.branch} at commit ${result.commit_sha}. Changed files: ${changedFiles}.`;
+		}
+
+		return `persist_work failed with error_code=${result.error_code}: ${result.message}`;
+	}
+
+	private truncateForPrompt(text: string, maxLength: number = 400): string {
+		const normalized = text.trim().replace(/\s+/g, " ");
+		if (normalized.length <= maxLength) {
+			return normalized;
+		}
+		return `${normalized.slice(0, maxLength - 3)}...`;
+	}
+
+	private executeReplaceInFile(action: {
+		path: string;
+		old_string: string;
+		new_string: string;
+		replace_all?: boolean;
+	}):
+		| { ok: true; path: string; replacements: number; message: string }
+		| {
+				ok: false;
+				path: string;
+				error_code: string;
+				message: string;
+		  } {
+		const repoRoot = resolve(process.cwd());
+		const targetPath = resolve(repoRoot, action.path);
+		if (!(targetPath === repoRoot || targetPath.startsWith(`${repoRoot}/`))) {
+			return {
+				ok: false,
+				path: action.path,
+				error_code: "path_outside_repo",
+				message: "replace_in_file may only target files inside the repository.",
+			};
+		}
+
+		if (!existsSync(targetPath)) {
+			return {
+				ok: false,
+				path: action.path,
+				error_code: "file_not_found",
+				message: "Target file does not exist.",
+			};
+		}
+
+		const original = readFileSync(targetPath, "utf8");
+		const matchCount = original.split(action.old_string).length - 1;
+		if (matchCount === 0) {
+			return {
+				ok: false,
+				path: action.path,
+				error_code: "old_string_not_found",
+				message: "old_string was not found in the target file.",
+			};
+		}
+
+		if (!action.replace_all && matchCount > 1) {
+			return {
+				ok: false,
+				path: action.path,
+				error_code: "ambiguous_match",
+				message:
+					"old_string matched multiple locations. Provide a more specific old_string or set replace_all to true.",
+			};
+		}
+
+		const updated = action.replace_all
+			? original.replaceAll(action.old_string, action.new_string)
+			: original.replace(action.old_string, action.new_string);
+		const replacements = action.replace_all ? matchCount : 1;
+		writeFileSync(targetPath, updated, "utf8");
+		return {
+			ok: true,
+			path: action.path,
+			replacements,
+			message: `Updated ${action.path} with ${replacements} replacement${replacements === 1 ? "" : "s"}.`,
 		};
 	}
 }


### PR DESCRIPTION
## Summary

This PR makes the task harness behave more like a coding agent and less like a brittle JSON-shell loop.

## What Changed

- adds a first-class `replace_in_file` action so task bots can make precise text edits without inventing shell patch scripts
- reduces continuation and loop-repair prompt replay to a compact task-state summary instead of full prior JSON and raw action output
- raises `developer-tester` to 2 actions per turn so it can bundle inspect+edit or edit+verify when that is the shortest useful step
- adds a read-only inspection stall reminder to push the developer toward action or an explicit blocker
- updates prompt partials and examples so the new action surface is actually reflected in the model-facing prompt

## Why

The recent failures showed the same harness problems repeatedly:

- developer burned turns on shell-script patching instead of editing directly
- continuation prompts recursively replayed prior protocol and terminal dumps
- one action per turn made simple coding loops artificially expensive
- the loop controls were too weak to interrupt repeated read-only inspection

## Impact

The developer bot now has a structured edit primitive, less recursive context, and a less constrained turn shape. This should make it much easier to complete small cross-file implementation increments without falling into inspection or patch-script loops.

## Validation

- `npx tsc --noEmit`
- `npx biome check src/ prompts/ bots.json`
- `npm run build`
- `npm test`
