### PR TITLE
[codex] Validate task packet file grounding

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -8,6 +8,8 @@ Planner rules:
 - if the design is missing approval or appears inconsistent with the source, stop and hand back that blocker instead of inventing implementation scope
 - keep plan steps small enough that `@developer-tester` can implement one increment and return control to Overseer
 - each plan should stay anchored to the approved design file and the current code layout
+- every implementation step should name real repository files that exist on the current branch, unless the step is explicitly about creating a new file
+- if the design references nonexistent files or made-up seams, stop and hand the task back for design repair instead of translating that drift into a developer task
 
 Your final response should summarize:
 

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -7,6 +7,9 @@ Architect rules:
 - write or update design artifacts directly in the repository, usually under `docs/architecture/`
 - if the task packet says the design is missing or needs revision, focus on the design doc itself rather than implementation
 - inspect the named source files before changing the design doc when the task is about repairing drift
+- ground every design change in actual repository files and symbols you have inspected
+- do not invent files, modules, classes, or abstractions that are not present in the current repository unless the design explicitly calls for creating a new file, and say so plainly when you do
+- if the repository structure does not support the intended change cleanly, say that explicitly in the design instead of pretending a seam already exists
 - do not implement product code; your deliverable is the design artifact
 - treat human approval as required before planning or implementation proceeds
 

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -14,6 +14,7 @@ Design approval rules:
 - if you are a planner or developer and `Design Approval Status` is not `approved`, stop and hand back the blocker instead of inventing scope
 - if you are the architect and the task says the design is missing or needs revision, focus on the design artifact until it is ready for human review
 - if the named design doc conflicts with the source, report the drift explicitly instead of silently implementing around it
+- if the canonical task packet lists missing files, stop and hand back the drift instead of searching for substitute files on your own
 
 Use the JSON action protocol to inspect the repository, verify results, and make changes only when your available actions permit it.
 

--- a/src/personas/task_persona.test.ts
+++ b/src/personas/task_persona.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { getBotOrThrow, loadBotRegistry } from "../bots/bot_config.js";
+import { TaskPersona } from "./task_persona.js";
+
+describe("TaskPersona", () => {
+	it("hands impossible task packets back to Overseer before invoking the LLM", async () => {
+		const registry = loadBotRegistry();
+		const bot = getBotOrThrow(registry, "developer-tester");
+		let startChatCalled = false;
+		const gemini = {
+			startChat() {
+				startChatCalled = true;
+				throw new Error("startChat should not be called for invalid packets");
+			},
+		};
+		const persistence = {
+			persistWork: async () => ({
+				ok: true as const,
+				branch: "bot/issue-1",
+				commit_sha: "abc123",
+				changed_files: [],
+				message: "Persisted successfully.",
+			}),
+		};
+		const persona = new TaskPersona(bot, gemini as never, persistence as never);
+
+		const result = await persona.handleTask(
+			"anicolao",
+			"overseer",
+			85,
+			[
+				"Developer Task:",
+				"Task ID: impossible-step",
+				"Design File: docs/design/persist-qa.md",
+				"Design Approval Status: approved",
+				"Plan File: docs/plans/persist-qa.md",
+				"Files To Read:",
+				"- src/action-types.ts",
+				"- src/action-handler.ts",
+				"Task Summary: Implement the invented dispatcher seam.",
+			].join("\n"),
+		);
+
+		expect(startChatCalled).toBe(false);
+		expect(result.handoffTo).toBe("@overseer");
+		expect(result.finalResponse).toContain("do not exist");
+		expect(result.finalResponse).toContain("repair the design/plan");
+	});
+});

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -11,6 +11,7 @@ import type { PersistenceService } from "../utils/persistence.js";
 import {
 	parseTaskPacket,
 	renderTaskPacketForPrompt,
+	validateTaskPacketForExecution,
 } from "../utils/task_packet.js";
 import { logTrace, textStats } from "../utils/trace.js";
 
@@ -41,6 +42,31 @@ export class TaskPersona {
 			`${this.bot.displayName} handling task for issue #${issueNumber}`,
 		);
 		const taskPacket = parseTaskPacket(taskBody);
+		const taskPacketValidation = validateTaskPacketForExecution(taskPacket);
+		if (!taskPacketValidation.ok) {
+			const finalResponse = [
+				`Blocked before execution: ${taskPacketValidation.message}`,
+				"",
+				"Required next step: route this back to the architect or planner to repair the design/plan so it references real files and seams from the current repository.",
+			].join("\n");
+			const log = [
+				"TASK PACKET PRECHECK FAILED",
+				`Missing files: ${taskPacketValidation.missingFiles.join(", ")}`,
+				`Raw body:\n${taskBody}`,
+			].join("\n\n");
+			logTrace("persona.task.precheckFailed", {
+				botId: this.bot.id,
+				displayName: this.bot.displayName,
+				issueNumber,
+				taskPacket,
+				taskPacketValidation,
+			});
+			return {
+				finalResponse,
+				handoffTo: "@overseer",
+				log,
+			};
+		}
 		const canonicalTaskBody = renderTaskPacketForPrompt(taskPacket);
 
 		logTrace("persona.task.promptPrepared", {

--- a/src/utils/task_packet.test.ts
+++ b/src/utils/task_packet.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseTaskPacket, renderTaskPacketForPrompt } from "./task_packet.js";
+import {
+	parseTaskPacket,
+	renderTaskPacketForPrompt,
+	validateTaskPacketForExecution,
+} from "./task_packet.js";
 
 describe("task_packet", () => {
 	it("parses the structured Architect Task handoff", () => {
@@ -141,7 +145,54 @@ describe("task_packet", () => {
 		expect(rendered).toContain(
 			"Likely Next Step: Expand coverage to the next token case.",
 		);
+		expect(rendered).toContain("Missing Files: docs/architecture/parser.md");
 		expect(rendered).toContain("Task Summary: Update the parser.");
 		expect(rendered).toContain("RAW DIRECTED TASK:");
+	});
+
+	it("flags missing execution files for planner and developer handoffs", () => {
+		const packet = parseTaskPacket(
+			[
+				"Developer Task:",
+				"Task ID: persist-qa-step",
+				"Design File: docs/design/persist-qa.md",
+				"Design Approval Status: approved",
+				"Plan File: docs/plans/persist-qa.md",
+				"Files To Read:",
+				"- src/action-types.ts",
+				"- src/action-handler.ts",
+				"Task Summary: Implement the dispatcher step.",
+			].join("\n"),
+		);
+
+		const validation = validateTaskPacketForExecution(packet);
+
+		expect(validation.ok).toBe(false);
+		expect(validation.missingFiles).toEqual([
+			"docs/design/persist-qa.md",
+			"docs/plans/persist-qa.md",
+			"src/action-types.ts",
+			"src/action-handler.ts",
+		]);
+		expect(validation.message).toContain("do not exist");
+	});
+
+	it("allows architects to create a missing design file", () => {
+		const packet = parseTaskPacket(
+			[
+				"Architect Task:",
+				"Task ID: create-design",
+				"Design File: docs/design/new-feature.md",
+				"Design Approval Status: missing",
+				"Files To Read:",
+				"- src/index.ts",
+				"Task Summary: Draft the missing design.",
+			].join("\n"),
+		);
+
+		const validation = validateTaskPacketForExecution(packet);
+
+		expect(validation.ok).toBe(true);
+		expect(validation.missingFiles).toEqual([]);
 	});
 });

--- a/src/utils/task_packet.ts
+++ b/src/utils/task_packet.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import { extractDirectedTask } from "./persona_helper.js";
 
 export interface TaskPacket {
@@ -19,6 +21,7 @@ export interface TaskPacket {
 	verificationCommands: string[];
 	likelyNextStep?: string;
 	supplementalContext?: string;
+	missingFiles: string[];
 }
 
 type StructuredTaskFields = {
@@ -49,6 +52,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 			taskSummary: directedTask,
 			progressEvidence: [],
 			verificationCommands: [],
+			missingFiles: [],
 		};
 	}
 
@@ -68,6 +72,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 		normalizeOptionalValue(parsed.taskSummary) ||
 		supplementalContext ||
 		directedTask;
+	const missingFiles = filesToRead.filter((path) => !pathExistsInRepo(path));
 
 	return {
 		rawBody: body,
@@ -94,6 +99,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 			.filter(Boolean),
 		likelyNextStep: normalizeOptionalValue(parsed.likelyNextStep),
 		supplementalContext: supplementalContext || undefined,
+		missingFiles,
 	};
 }
 
@@ -121,6 +127,9 @@ export function renderTaskPacketForPrompt(packet: TaskPacket): string {
 			packet.verificationCommands.length > 0
 				? packet.verificationCommands.join(" | ")
 				: "none"
+		}`,
+		`- Missing Files: ${
+			packet.missingFiles.length > 0 ? packet.missingFiles.join(", ") : "none"
 		}`,
 		`- Likely Next Step: ${packet.likelyNextStep || "none"}`,
 	];
@@ -311,7 +320,7 @@ function splitFilesToRead(value: string): string[] {
 	}
 	return normalized
 		.split(",")
-		.map((entry) => entry.trim())
+		.map((entry) => normalizePathReference(entry))
 		.filter(Boolean);
 }
 
@@ -324,4 +333,49 @@ function normalizeOptionalValue(value?: string): string | undefined {
 		return undefined;
 	}
 	return trimmed;
+}
+
+function normalizePathReference(value: string): string {
+	const trimmed = value.trim();
+	const match = trimmed.match(/^([A-Za-z0-9._/-]+\/?)/);
+	return match?.[1]?.trim() || trimmed;
+}
+
+function pathExistsInRepo(relativePath: string): boolean {
+	const normalizedPath = relativePath.replace(/\/+$/, "");
+	if (!normalizedPath) {
+		return false;
+	}
+	return existsSync(resolve(process.cwd(), normalizedPath));
+}
+
+export function validateTaskPacketForExecution(packet: TaskPacket): {
+	ok: boolean;
+	missingFiles: string[];
+	message?: string;
+} {
+	if (!packet.hasStructuredHandoff) {
+		return { ok: true, missingFiles: [] };
+	}
+
+	const missingFiles = packet.missingFiles.filter((path) => {
+		if (
+			packet.handoffType === "architect" &&
+			packet.designFile === path &&
+			packet.designApprovalStatus === "missing"
+		) {
+			return false;
+		}
+		return true;
+	});
+
+	if (missingFiles.length === 0) {
+		return { ok: true, missingFiles: [] };
+	}
+
+	return {
+		ok: false,
+		missingFiles,
+		message: `Task packet references files that do not exist in the current repository state: ${missingFiles.join(", ")}. The design or plan does not match the source and must be repaired before this task can continue.`,
+	};
 }


### PR DESCRIPTION
## Summary

This PR blocks impossible planner/developer task packets before they reach the worker LLM and tightens architect/planner grounding rules.

## What Changed

- validates structured task packets against the current repository state before task execution
- hands invalid packets back to Overseer immediately instead of burning a full developer or planner run
- adds missing-file visibility to the canonical task packet prompt
- strengthens architect and planner prompts so they must anchor designs and plans to real repo files and seams

## Why

The live persist_qa issue still produced developer tasks against nonexistent files like `src/action-types.ts` and `src/action-handler.ts`. That means the real failure mode is still stale design/plan grounding, not developer execution once a valid slice exists.

## Validation

- `npx vitest run src/utils/task_packet.test.ts src/personas/task_persona.test.ts src/bots/bot_config.test.ts`
- `npx tsc --noEmit`
- `npx biome check src/ prompts/`
- `npm run build`
- `npm test`
