### PR TITLE
[codex] Allow overseer to retry same specialist

### DIFF
--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -83,6 +83,7 @@ Requirements for Overseer handoffs:
 - if there is no approved design in the issue context, do not delegate implementation
 - route missing or stale artifacts back to the specialist who owns them instead of patching around them in a developer handoff
 - if a previous specialist run failed on the same step, avoid improvising a more detailed technical fix yourself; prefer rerouting to the appropriate specialist or to human review
+- if a specialist times out or reports a blocker that still belongs with that same specialty, you may send a repaired task back to that same specialist instead of escalating immediately to human review
 - every developer task must define `Current Step`, `Smallest Useful Increment`, `Stop After`, and `Done When`
 - every planner or developer task must name an approved `Design File`
 - write `Done When` for the current increment, not the whole issue

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -6,7 +6,7 @@ Strict rules:
 
 1. You must not write implementation code or repository documentation directly.
 2. Give exactly one bite-sized next task at a time.
-3. Do not assign the next action back to the same agent you just received a response from unless human review is required.
+3. Do not assign the next action back to the same agent you just received a response from unless human review is required or the latest response was a blocker, timeout, or repair request that still belongs with that same specialist after you fix the task packet.
 4. If another agent claims to have created or updated files, inspect those files before deciding the next action.
 5. You must never use `persist_work`.
 6. Use `run_ro_shell` for inspection. Do not use `run_shell`.

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -49,6 +49,9 @@ describe("bot_config", () => {
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"if implementation uncovers a missing step or architectural omission, send the work back to `@product-architect` or `@planner`",
 		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"you may send a repaired task back to that same specialist instead of escalating immediately to human review",
+		);
 	});
 
 	it("exposes overseer and task bots through the registry", () => {

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -131,10 +131,17 @@ export class OverseerPersona {
 		);
 		const latestResponder =
 			_commenterPersona || commenter || "unknown responder";
+		const retryingSameSpecialistIsAllowed =
+			/(ERROR:\s*Max iterations reached|Blocker:|failed to|does not exist|needs revision|needs repair)/i.test(
+				body,
+			);
+		const sameResponderGuardrail = retryingSameSpecialistIsAllowed
+			? `- Do not assign the next step back to ${latestResponder} unless the latest response is a blocker, timeout, or repair request that still belongs with that specialist after you fix the task packet.`
+			: `- Do not assign the next step back to ${latestResponder}.`;
 		const taskBody = `The issue has been updated. The latest response came from ${latestResponder}. Review the full context and decide the next micro-task.
 
 Guardrails:
-- Do not assign the next step back to ${latestResponder}.
+${sameResponderGuardrail}
 - If ${latestResponder} claims to have created or updated files, read those files before deciding the next action.
 
 CONTEXT:


### PR DESCRIPTION
## Summary

This PR lets Overseer retry the same specialist when the previous response was a blocker, timeout, or repair request, instead of forcing immediate human escalation.

## Why

On the live persist_qa issue, developer correctly flagged nonexistent files, Overseer routed the design back to Product/Architect, and then the architect timed out. Overseer escalated to human only because the comment-routing guardrail prohibited assigning work back to the same specialist that had just replied, even though the task still clearly belonged with that specialist.

## Validation

- `npx vitest run src/bots/bot_config.test.ts`
- `npx tsc --noEmit`
- `npm test`
