### PR TITLE
Make design repair handoffs semantic

### DIFF
--- a/bots.json
+++ b/bots.json
@@ -30,7 +30,7 @@
 			"shell_access": "read_write",
 			"allow_persist_work": true,
 			"max_iterations": 10,
-			"max_actions_per_turn": 1,
+			"max_actions_per_turn": 2,
 			"prompt_files": [
 				"prompts/shared/task-agent.md",
 				"prompts/shared/persisting-agent.md",
@@ -44,7 +44,7 @@
 			"shell_access": "read_write",
 			"allow_persist_work": true,
 			"max_iterations": 10,
-			"max_actions_per_turn": 1,
+			"max_actions_per_turn": 2,
 			"prompt_files": [
 				"prompts/shared/task-agent.md",
 				"prompts/shared/persisting-agent.md",

--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -84,6 +84,8 @@ Requirements for Overseer handoffs:
 - route missing or stale artifacts back to the specialist who owns them instead of patching around them in a developer handoff
 - if a previous specialist run failed on the same step, avoid improvising a more detailed technical fix yourself; prefer rerouting to the appropriate specialist or to human review
 - if a specialist times out or reports a blocker that still belongs with that same specialty, you may send a repaired task back to that same specialist instead of escalating immediately to human review
+- when routing a design repair, describe the underlying mismatch in terms of the real repository seam that must be rewritten, not just the stale filenames a previous run expected
+- do not frame design repair as a literal search-and-replace task unless you have verified the stale text actually appears in the artifact
 - every developer task must define `Current Step`, `Smallest Useful Increment`, `Stop After`, and `Done When`
 - every planner or developer task must name an approved `Design File`
 - write `Done When` for the current increment, not the whole issue

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -8,6 +8,10 @@ Architect rules:
 - if the task packet says the design is missing or needs revision, focus on the design doc itself rather than implementation
 - inspect the named source files before changing the design doc when the task is about repairing drift
 - ground every design change in actual repository files and symbols you have inspected
+- when repairing drift, treat the blocker as a semantic mismatch, not just a literal string replacement task
+- if the stale file names or abstractions do not appear verbatim in the design doc, rewrite the affected design section anyway so it names the real files and seams from the current repository
+- after one inspection pass, prefer directly rewriting the stale section over repeated grep or search-only turns
+- if an attempted design edit produces no diff, stop searching and rewrite the relevant section explicitly
 - do not invent files, modules, classes, or abstractions that are not present in the current repository unless the design explicitly calls for creating a new file, and say so plainly when you do
 - if the repository structure does not support the intended change cleanly, say that explicitly in the design instead of pretending a seam already exists
 - do not implement product code; your deliverable is the design artifact

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -14,3 +14,4 @@ Strict rules:
 8. Put the actual delegation in `final_response`. Do not use `github_comment` for final handoff instructions.
 9. Do not invent implementation details, architecture fixes, or retry instructions that belong to a specialist bot.
 10. If the current design, plan, or implementation is wrong or incomplete, route the work to the correct specialist bot or to human review instead of improvising a solution yourself.
+11. When a specialist reports stale docs or missing files, restate the mismatch as an artifact repair problem for the owning specialist; do not reduce it to a literal string replacement task unless you verified the stale text is actually present.

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -15,6 +15,7 @@ Design approval rules:
 - if you are the architect and the task says the design is missing or needs revision, focus on the design artifact until it is ready for human review
 - if the named design doc conflicts with the source, report the drift explicitly instead of silently implementing around it
 - if the canonical task packet lists missing files, stop and hand back the drift instead of searching for substitute files on your own
+- if a blocker says an artifact is stale or mismatched, treat that as a semantic repair task even when the stale wording is not present verbatim
 
 Use the JSON action protocol to inspect the repository, verify results, and make changes only when your available actions permit it.
 
@@ -23,4 +24,6 @@ Execution discipline:
 - keep the next step narrowly scoped to one immediate action
 - once one meaningful increment is complete, stop, report progress, and return control to Overseer
 - after at most two inspection turns, either start editing, run verification, or explain the blocker
+- for architect or planner repair tasks, after inspecting the named files once, the next turn should update the artifact or report a blocker instead of continuing broad search
+- if an intended edit produces no diff, do not keep searching for literal text; rewrite the relevant section directly or explain the mismatch
 - if a command fails, report a blocker

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -40,6 +40,13 @@ describe("bot_config", () => {
 		expect(developer.prompt.concatenatedPrompt).not.toContain(
 			"BEGIN PROMPT FILE:",
 		);
+		expect(getBotOrThrow(registry, "product-architect").maxActionsPerTurn).toBe(
+			2,
+		);
+		expect(getBotOrThrow(registry, "planner").maxActionsPerTurn).toBe(2);
+		expect(
+			getBotOrThrow(registry, "product-architect").prompt.concatenatedPrompt,
+		).toContain("treat the blocker as a semantic mismatch");
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"You are a router of tasks, not a solver of technical subtasks.",
 		);
@@ -51,6 +58,9 @@ describe("bot_config", () => {
 		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"you may send a repaired task back to that same specialist instead of escalating immediately to human review",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"do not frame design repair as a literal search-and-replace task unless you have verified the stale text actually appears in the artifact",
 		);
 	});
 


### PR DESCRIPTION
## Summary
- make architect design-repair prompts treat drift as a semantic mismatch instead of literal string replacement
- let product-architect and planner take up to 2 actions per turn for inspect+edit style doc work
- tighten overseer handoff instructions so design repairs are framed around the real repo seam

## Validation
- npm run lint
- npx vitest run src/bots/bot_config.test.ts
- npx tsc --noEmit
- npm test