### PR TITLE
Guide architect repair tasks semantically

### DIFF
--- a/src/personas/task_persona.test.ts
+++ b/src/personas/task_persona.test.ts
@@ -46,4 +46,66 @@ describe("TaskPersona", () => {
 		expect(result.finalResponse).toContain("do not exist");
 		expect(result.finalResponse).toContain("repair the design/plan");
 	});
+
+	it("adds a semantic repair note for architect revision tasks", async () => {
+		const registry = loadBotRegistry();
+		const bot = getBotOrThrow(registry, "product-architect");
+		let receivedInitialMessage = "";
+		const gemini = {
+			startChat() {
+				return {
+					sendMessage: async (message: string) => {
+						receivedInitialMessage = message;
+						return {
+							text: JSON.stringify({
+								version: "overseer/v1",
+								plan: ["Read the design artifact."],
+								next_step: "Stop with a blocker for test purposes.",
+								actions: [],
+								task_status: "done",
+								final_response: "Blocked for test.",
+								handoff_to: "@overseer",
+							}),
+						};
+					},
+				};
+			},
+		};
+		const persistence = {
+			persistWork: async () => ({
+				ok: true as const,
+				branch: "bot/issue-1",
+				commit_sha: "abc123",
+				changed_files: [],
+				message: "Persisted successfully.",
+			}),
+		};
+		const persona = new TaskPersona(bot, gemini as never, persistence as never);
+
+		await persona.handleTask(
+			"anicolao",
+			"overseer",
+			85,
+			[
+				"Architect Task:",
+				"Task ID: repair-design",
+				"Design File: docs/current-system.md",
+				"Design Approval Status: needs_revision",
+				"Files To Read:",
+				"- src/utils/agent_protocol.ts",
+				"- src/dispatch.ts",
+				"Current Step: Rewrite the stale design sections against the real source files.",
+				"Task Summary: Repair the design to match the current repository seams.",
+				"Done When: The design file names the real implementation files and seams.",
+			].join("\n"),
+		);
+
+		expect(receivedInitialMessage).toContain("REPAIR EXECUTION NOTE:");
+		expect(receivedInitialMessage).toContain(
+			"This is a semantic design-repair task.",
+		);
+		expect(receivedInitialMessage).toContain(
+			"Do not spend multiple turns searching for literal stale strings.",
+		);
+	});
 });

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -68,6 +68,10 @@ export class TaskPersona {
 			};
 		}
 		const canonicalTaskBody = renderTaskPacketForPrompt(taskPacket);
+		const taskPromptBody = this.buildTaskPromptBody(
+			taskPacket,
+			canonicalTaskBody,
+		);
 
 		logTrace("persona.task.promptPrepared", {
 			botId: this.bot.id,
@@ -76,8 +80,8 @@ export class TaskPersona {
 			taskBody: textStats(taskBody),
 			taskBodyRaw: taskBody,
 			taskPacket,
-			canonicalTaskBody: textStats(canonicalTaskBody),
-			canonicalTaskBodyRaw: canonicalTaskBody,
+			canonicalTaskBody: textStats(taskPromptBody),
+			canonicalTaskBodyRaw: taskPromptBody,
 			shellAccess: this.bot.shellAccess,
 			allowPersistWork: this.bot.allowPersistWork,
 			maxIterations: this.bot.maxIterations,
@@ -105,9 +109,33 @@ export class TaskPersona {
 		return this.runner.runAutonomousLoop(
 			this.gemini,
 			this.bot.prompt.concatenatedPrompt,
-			canonicalTaskBody,
+			taskPromptBody,
 			this.bot.maxIterations,
 			runnerOptions,
 		);
+	}
+
+	private buildTaskPromptBody(
+		taskPacket: ReturnType<typeof parseTaskPacket>,
+		canonicalTaskBody: string,
+	): string {
+		if (
+			taskPacket.handoffType === "architect" &&
+			taskPacket.designApprovalStatus === "needs_revision"
+		) {
+			const artifact = taskPacket.designFile || "the design artifact";
+			return [
+				"REPAIR EXECUTION NOTE:",
+				"- This is a semantic design-repair task.",
+				"- The stale file names or abstractions may not appear verbatim in the current design doc.",
+				`- After you inspect the named files once, rewrite the affected sections in ${artifact} so they name the real files, symbols, and seams from the current repository.`,
+				"- Do not spend multiple turns searching for literal stale strings.",
+				"- A no-op search or replace does not satisfy the task; you must leave a real diff in the design artifact or report a blocker.",
+				"",
+				canonicalTaskBody,
+			].join("\n");
+		}
+
+		return canonicalTaskBody;
 	}
 }

--- a/src/utils/shell.test.ts
+++ b/src/utils/shell.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { ShellService, wrapInNixDevelop } from "./shell.js";
 
@@ -19,15 +20,22 @@ describe("wrapInNixDevelop", () => {
 
 describe("ShellService read-only execution", () => {
 	it("prevents writes to repository files in run_ro_shell mode", async () => {
-		const repoDir = resolve(process.cwd());
-		const before = readFileSync(resolve(repoDir, "package.json"), "utf8");
-		const shell = new ShellService(repoDir, (command) => command);
-		const result = await shell.executeCommand(
-			"printf '\\n// should not be written\\n' >> package.json",
-			"read_only",
-		);
+		const repoDir = mkdtempSync(join(tmpdir(), "overseer-shell-test-"));
+		const packageJsonPath = join(repoDir, "package.json");
+		writeFileSync(packageJsonPath, '{ "name": "fixture" }\n', "utf8");
 
-		expect(result.exitCode).not.toBe(0);
-		expect(readFileSync(resolve(repoDir, "package.json"), "utf8")).toBe(before);
+		try {
+			const before = readFileSync(packageJsonPath, "utf8");
+			const shell = new ShellService(repoDir, (command) => command);
+			const result = await shell.executeCommand(
+				"printf '\\n// should not be written\\n' >> package.json",
+				"read_only",
+			);
+
+			expect(result.exitCode).not.toBe(0);
+			expect(readFileSync(packageJsonPath, "utf8")).toBe(before);
+		} finally {
+			rmSync(repoDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -8,7 +8,7 @@ import {
 	rmSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, relative } from "node:path";
 import { promisify } from "node:util";
 import type { AgentAction } from "./agent_protocol.js";
 import { logTrace, serializeError, textStats } from "./trace.js";
@@ -224,7 +224,11 @@ function createReadOnlySandbox(sourceRepoRoot: string): {
 	mkdirSync(homeDir, { recursive: true });
 	mkdirSync(tempDir, { recursive: true });
 
-	cpSync(sourceRepoRoot, repoDir, { recursive: true });
+	cpSync(sourceRepoRoot, repoDir, {
+		recursive: true,
+		filter: (sourcePath) =>
+			shouldCopyIntoReadOnlySandbox(sourceRepoRoot, sourcePath),
+	});
 	makeDirectoryTreeReadOnly(repoDir);
 
 	return {
@@ -233,6 +237,28 @@ function createReadOnlySandbox(sourceRepoRoot: string): {
 		homeDir,
 		tmpDir: tempDir,
 	};
+}
+
+function shouldCopyIntoReadOnlySandbox(
+	sourceRepoRoot: string,
+	sourcePath: string,
+): boolean {
+	const relPath = relative(sourceRepoRoot, sourcePath);
+	if (relPath === "") {
+		return true;
+	}
+
+	const normalizedRelPath = relPath.replaceAll("\\", "/");
+	const topLevelEntry = normalizedRelPath.split("/", 1)[0];
+	if (!topLevelEntry) {
+		return true;
+	}
+
+	if (topLevelEntry === ".artifacts" || topLevelEntry === ".backstop") {
+		return false;
+	}
+
+	return !/^session_.*\.log$/.test(topLevelEntry);
 }
 
 function makeDirectoryTreeReadOnly(path: string): void {


### PR DESCRIPTION
## Summary
- add a runtime repair-execution note for architect revision tasks so stale docs are repaired semantically instead of by literal string hunting
- keep the task-persona prompt body explicit about rewriting the artifact after one inspection pass
- speed up the read-only shell sandbox and make the shell test use a tiny temp repo fixture

## Validation
- npm run lint
- npx tsc --noEmit
- npm test