### PR TITLE
Preserve human constraint details in overseer handoffs

### DIFF
--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -86,6 +86,8 @@ Requirements for Overseer handoffs:
 - if a specialist times out or reports a blocker that still belongs with that same specialty, you may send a repaired task back to that same specialist instead of escalating immediately to human review
 - when routing a design repair, describe the underlying mismatch in terms of the real repository seam that must be rewritten, not just the stale filenames a previous run expected
 - do not frame design repair as a literal search-and-replace task unless you have verified the stale text actually appears in the artifact
+- if the latest human comment names specific capabilities, actions, bots, or prompt/config artifacts, preserve those constraints in the next handoff instead of reducing them to a narrower paraphrase
+- when the latest human comment contains a concrete correction, prefer carrying that correction forward literally in `Files To Read`, `Current Step`, and `Task Summary`
 - every developer task must define `Current Step`, `Smallest Useful Increment`, `Stop After`, and `Done When`
 - every planner or developer task must name an approved `Design File`
 - write `Done When` for the current increment, not the whole issue

--- a/prompts/shared/overseer-core.md
+++ b/prompts/shared/overseer-core.md
@@ -15,3 +15,4 @@ Strict rules:
 9. Do not invent implementation details, architecture fixes, or retry instructions that belong to a specialist bot.
 10. If the current design, plan, or implementation is wrong or incomplete, route the work to the correct specialist bot or to human review instead of improvising a solution yourself.
 11. When a specialist reports stale docs or missing files, restate the mismatch as an artifact repair problem for the owning specialist; do not reduce it to a literal string replacement task unless you verified the stale text is actually present.
+12. When the latest human comment contains explicit corrections about capabilities, actions, prompt files, config files, or runtime seams, carry those corrections forward into the next handoff instead of collapsing them into a partial summary.

--- a/src/personas/overseer.test.ts
+++ b/src/personas/overseer.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { extractRepoPathMentions } from "./overseer.js";
+import {
+	extractQuotedCorrectionMentions,
+	extractRepoPathMentions,
+} from "./overseer.js";
 
 describe("extractRepoPathMentions", () => {
 	it("extracts repo paths from human correction comments", () => {
@@ -17,5 +20,19 @@ describe("extractRepoPathMentions", () => {
 			"src/personas/task_persona.ts",
 			"src/bots/bot_config.ts",
 		]);
+	});
+});
+
+describe("extractQuotedCorrectionMentions", () => {
+	it("extracts non-path quoted constraints from human correction comments", () => {
+		const mentions = extractQuotedCorrectionMentions(
+			[
+				"@overseer the design still drifts.",
+				"Please cover both `persist_qa` and `run_shell` for `@quality`,",
+				"and distinguish `prompts/quality.md` from `src/personas/task_persona.ts`.",
+			].join(" "),
+		);
+
+		expect(mentions).toEqual(["persist_qa", "run_shell", "@quality"]);
 	});
 });

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -25,6 +25,22 @@ export function extractRepoPathMentions(text: string): string[] {
 	return [...paths];
 }
 
+export function extractQuotedCorrectionMentions(text: string): string[] {
+	const matches = text.matchAll(/`([^`\n]+)`/g);
+	const mentions = new Set<string>();
+	for (const match of matches) {
+		const value = match[1]?.trim();
+		if (!value || /^(?:src|prompts|docs)\//.test(value)) {
+			continue;
+		}
+		if (value === "bots.json" || value === "AGENTS.md") {
+			continue;
+		}
+		mentions.add(value);
+	}
+	return [...mentions];
+}
+
 export class OverseerPersona {
 	private bot: LoadedBotDefinition;
 	private gemini: GeminiService;
@@ -153,6 +169,7 @@ export class OverseerPersona {
 			? `- Do not assign the next step back to ${latestResponder} unless the latest response is a blocker, timeout, or repair request that still belongs with that specialist after you fix the task packet.`
 			: `- Do not assign the next step back to ${latestResponder}.`;
 		const explicitRepoPaths = extractRepoPathMentions(body);
+		const explicitCorrectionMentions = extractQuotedCorrectionMentions(body);
 		const explicitRepoPathsSection =
 			explicitRepoPaths.length > 0
 				? `\nExplicit repo paths mentioned in the latest comment:\n${explicitRepoPaths
@@ -161,12 +178,24 @@ export class OverseerPersona {
 							"\n",
 						)}\n- Preserve these paths in the next handoff when they are relevant to the correction or blocker.`
 				: "";
+		const explicitCorrectionMentionsSection =
+			explicitCorrectionMentions.length > 0
+				? `\nExplicit quoted constraints from the latest comment:\n${explicitCorrectionMentions
+						.map((value) => `- ${value}`)
+						.join(
+							"\n",
+						)}\n- Preserve these quoted constraints in the next handoff's Current Step, Task Summary, Files To Read, or Done When when they are relevant to the correction or blocker.`
+				: "";
 		const taskBody = `The issue has been updated. The latest response came from ${latestResponder}. Review the full context and decide the next micro-task.
 
 Guardrails:
 ${sameResponderGuardrail}
 - If ${latestResponder} claims to have created or updated files, read those files before deciding the next action.
-- If the latest comment names specific repository files or corrects the execution seam, preserve those corrections in the next handoff's Files To Read and Current Step instead of falling back to generic related files.${explicitRepoPathsSection}
+- If the latest comment names specific repository files or corrects the execution seam, preserve those corrections in the next handoff's Files To Read and Current Step instead of falling back to generic related files.
+- If the latest comment gives explicit capability, action, prompt, or bot-role corrections, preserve those corrections in the next handoff instead of collapsing them into a partial summary.${explicitRepoPathsSection}${explicitCorrectionMentionsSection}
+
+LATEST COMMENT TO PRESERVE LITERALLY WHEN RELEVANT:
+${body}
 
 CONTEXT:
 ${fullContext}`;


### PR DESCRIPTION
## Summary
- preserve explicit non-path constraints from the latest human correction in overseer comment handling
- inject the latest comment body literally into the overseer routing prompt when relevant
- strengthen overseer prompt guidance to carry capability, action, bot, prompt, and config corrections forward

## Testing
- npx vitest run src/personas/overseer.test.ts src/bots/bot_config.test.ts
- npx biome check src/personas/overseer.ts src/personas/overseer.test.ts prompts/overseer.md prompts/shared/overseer-core.md
- npx tsc --noEmit
- npm test
