### PR TITLE
Ignore code-formatted persona mentions

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -13,8 +13,10 @@ import {
 } from "./utils/handoff.js";
 import { PersistenceService } from "./utils/persistence.js";
 import {
+	extractPersonaMentions,
 	getAttribution,
 	hasExplicitPersonaMention,
+	stripMarkdownCode,
 } from "./utils/persona_helper.js";
 import { truncate } from "./utils/text.js";
 import {
@@ -215,16 +217,18 @@ async function run() {
 
 		// 2. Identify target persona
 		let targetedPersona: string | null = null;
-		const nextStepMatch = body.match(/Next step: (@[a-z-]+)/i);
+		const bodyWithoutCodeMentions = extractPersonaMentions(
+			body.replace(/Next step:/gi, "\nNext step: "),
+		);
+		const nextStepMatch = stripNextStepHandle(body);
 		if (nextStepMatch) {
-			targetedPersona = handleMap[nextStepMatch[1].toLowerCase()] || null;
+			targetedPersona = handleMap[nextStepMatch.toLowerCase()] || null;
 		}
 		if (!targetedPersona) {
-			const mentions = body.match(/@[a-z-]+/gi);
-			if (mentions) {
+			if (bodyWithoutCodeMentions.length > 0) {
 				// Search from the end to find the most recent handoff
-				for (let i = mentions.length - 1; i >= 0; i--) {
-					const handle = mentions[i].toLowerCase();
+				for (let i = bodyWithoutCodeMentions.length - 1; i >= 0; i--) {
+					const handle = bodyWithoutCodeMentions[i].toLowerCase();
 					if (handleMap[handle]) {
 						targetedPersona = handleMap[handle];
 						break;
@@ -379,6 +383,12 @@ async function run() {
 			);
 		});
 	}
+}
+
+function stripNextStepHandle(body: string): string | null {
+	const sanitized = stripMarkdownCode(body);
+	const nextStepMatch = sanitized.match(/Next step: (@[a-z-]+)/i);
+	return nextStepMatch?.[1] || null;
 }
 
 async function finalizeRun(

--- a/src/utils/persona_helper.test.ts
+++ b/src/utils/persona_helper.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { hasExplicitPersonaMention, isLimitReached } from "./persona_helper.js";
+import {
+	extractPersonaMentions,
+	hasExplicitPersonaMention,
+	isLimitReached,
+	stripMarkdownCode,
+} from "./persona_helper.js";
 
 describe("hasExplicitPersonaMention", () => {
 	it("detects an explicit overseer mention in issue text", () => {
@@ -22,6 +27,41 @@ describe("hasExplicitPersonaMention", () => {
 				"@overseer",
 			),
 		).toBe(false);
+	});
+
+	it("ignores persona handles inside inline code", () => {
+		expect(
+			hasExplicitPersonaMention(
+				"Use `@overseer` literally in the example, but do not wake it.",
+				"@overseer",
+			),
+		).toBe(false);
+	});
+});
+
+describe("stripMarkdownCode", () => {
+	it("removes inline and fenced code spans", () => {
+		expect(
+			stripMarkdownCode(
+				"Before `@quality` after\n```md\nNext step: @planner\n``` tail",
+			),
+		).toBe("Before   after\n  tail");
+	});
+});
+
+describe("extractPersonaMentions", () => {
+	it("ignores quoted persona handles inside code spans", () => {
+		expect(
+			extractPersonaMentions(
+				[
+					"Wake @overseer for this correction.",
+					"Do not route to `@quality` from this quoted requirement.",
+					"```md",
+					"Next step: @planner",
+					"```",
+				].join("\n"),
+			),
+		).toEqual(["@overseer"]);
 	});
 });
 

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -1,5 +1,9 @@
 import type { GitHubService } from "./github.js";
 
+export function stripMarkdownCode(text: string): string {
+	return text.replace(/```[\s\S]*?```/g, " ").replace(/`[^`\n]+`/g, " ");
+}
+
 export function getAttribution(
 	personaName: string,
 	issueNumber: number,
@@ -36,8 +40,13 @@ export function hasExplicitPersonaMention(
 	text: string,
 	personaHandle: string,
 ): boolean {
+	const plainText = stripMarkdownCode(text);
 	const escapedHandle = personaHandle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	return new RegExp(`(^|\\s)${escapedHandle}(?=\\s|$)`, "i").test(text);
+	return new RegExp(`(^|\\s)${escapedHandle}(?=\\s|$)`, "i").test(plainText);
+}
+
+export function extractPersonaMentions(text: string): string[] {
+	return stripMarkdownCode(text).match(/@[a-z-]+/gi) ?? [];
 }
 
 export async function isLimitReached(


### PR DESCRIPTION
Avoid routing issue comments to bots mentioned only inside code spans.\n\nTesting: npx vitest run src/utils/persona_helper.test.ts src/personas/overseer.test.ts src/bots/bot_config.test.ts; npx biome check src/dispatch.ts src/utils/persona_helper.ts src/utils/persona_helper.test.ts; npx tsc --noEmit; npm test