### PR TITLE
Route explicit design repairs directly

### DIFF
--- a/src/personas/overseer.test.ts
+++ b/src/personas/overseer.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { getBotOrThrow, loadBotRegistry } from "../bots/bot_config.js";
 import {
+	extractDesignDocPath,
 	extractQuotedCorrectionMentions,
 	extractRepoPathMentions,
+	OverseerPersona,
 } from "./overseer.js";
 
 describe("extractRepoPathMentions", () => {
@@ -34,5 +37,56 @@ describe("extractQuotedCorrectionMentions", () => {
 		);
 
 		expect(mentions).toEqual(["persist_qa", "run_shell", "@quality"]);
+	});
+});
+
+describe("extractDesignDocPath", () => {
+	it("finds a design doc path in text", () => {
+		expect(
+			extractDesignDocPath(
+				"Please revise `docs/design/persist-qa.md` before implementation.",
+			),
+		).toBe("docs/design/persist-qa.md");
+	});
+});
+
+describe("OverseerPersona direct design repair routing", () => {
+	it("routes explicit human design corrections directly back to the architect", async () => {
+		const registry = loadBotRegistry();
+		const bot = getBotOrThrow(registry, "overseer");
+		const github = {
+			getIssueCommentCount: async () => 0,
+			getIssue: async () => ({ data: { body: "@overseer" } }),
+			getFullIssueContext: async () =>
+				[
+					"ISSUE TITLE: MVP validation: persist_qa end-to-end",
+					"",
+					"Existing design: docs/design/persist-qa.md",
+				].join("\n"),
+		};
+		const persona = new OverseerPersona(bot, {} as never, github as never);
+
+		const result = await persona.handleComment(
+			"anicolao",
+			"overseer",
+			85,
+			"anicolao",
+			[
+				"@overseer I still do not approve the design.",
+				"Revise it so it explicitly covers both `persist_qa` and `run_shell` for the quality bot,",
+				"and distinguish `prompts/quality.md`, `bots.json`, `src/bots/bot_config.ts`,",
+				"`src/utils/agent_protocol.ts`, and `src/utils/agent_runner.ts`.",
+			].join(" "),
+		);
+
+		expect(result.handoffTo).toBe("@product-architect");
+		expect(result.finalResponse).toContain("Architect Task:");
+		expect(result.finalResponse).toContain(
+			"Design File: docs/design/persist-qa.md",
+		);
+		expect(result.finalResponse).toContain("- prompts/quality.md");
+		expect(result.finalResponse).toContain("- bots.json");
+		expect(result.finalResponse).toContain("persist_qa");
+		expect(result.finalResponse).toContain("run_shell");
 	});
 });

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -41,6 +41,35 @@ export function extractQuotedCorrectionMentions(text: string): string[] {
 	return [...mentions];
 }
 
+export function extractDesignDocPath(text: string): string | null {
+	const match = text.match(
+		/(?:^|[`(\s])((?:docs\/(?:design|architecture)\/[A-Za-z0-9_./-]+\.md))(?=$|[`),.\s])/i,
+	);
+	return match?.[1]?.trim() || null;
+}
+
+function normalizeHumanCorrection(body: string): string {
+	return body.replace(/^@overseer\b\s*/i, "").trim();
+}
+
+function shouldDirectRouteDesignRepair(
+	body: string,
+	commenterPersona: string | undefined,
+	explicitRepoPaths: string[],
+	explicitCorrectionMentions: string[],
+): boolean {
+	if (commenterPersona) {
+		return false;
+	}
+	return (
+		/design/i.test(body) &&
+		/(do not approve|still do not approve|retry the design repair|revise the design)/i.test(
+			body,
+		) &&
+		(explicitRepoPaths.length > 0 || explicitCorrectionMentions.length > 0)
+	);
+}
+
 export class OverseerPersona {
 	private bot: LoadedBotDefinition;
 	private gemini: GeminiService;
@@ -75,6 +104,54 @@ export class OverseerPersona {
 				llm: this.bot.llm,
 				...summarizePromptAssembly(this.bot.prompt),
 			},
+		};
+	}
+
+	private buildDirectDesignRepairResponse(
+		body: string,
+		fullContext: string,
+		explicitRepoPaths: string[],
+		explicitCorrectionMentions: string[],
+	): IterationResult {
+		const designFile =
+			extractDesignDocPath(body) || extractDesignDocPath(fullContext);
+		const filesToRead = Array.from(
+			new Set(
+				[designFile, ...explicitRepoPaths].filter((value): value is string =>
+					Boolean(value),
+				),
+			),
+		);
+		const correction = normalizeHumanCorrection(body);
+		const currentStep = designFile
+			? `Revise ${designFile} so it explicitly incorporates the latest human correction, including ${explicitCorrectionMentions.join(", ") || "the named repository seams"}, and matches the current repository files.`
+			: `Revise the active design doc so it explicitly incorporates the latest human correction, including ${explicitCorrectionMentions.join(", ") || "the named repository seams"}, and matches the current repository files.`;
+		const doneWhen = designFile
+			? `${designFile} explicitly covers the latest human correction, matches the named prompt/config/protocol/runtime seams from the repository, and is ready for human approval.`
+			: `The active design doc explicitly covers the latest human correction, matches the named prompt/config/protocol/runtime seams from the repository, and is ready for human approval.`;
+		const lines = [
+			"The human has provided a concrete design correction. I am routing that correction directly back to the Product/Architect without paraphrasing it away.",
+			"",
+			"Architect Task:",
+			"Task ID: MVP validation: persist_qa end-to-end",
+			`Design File: ${designFile || "none"}`,
+			"Design Approval Status: needs_revision",
+			"Files To Read:",
+			...(filesToRead.length > 0
+				? filesToRead.map((path) => `- ${path}`)
+				: ["- none"]),
+			`Current Step: ${currentStep}`,
+			`Task Summary: Rewrite the stale design sections so they match this human correction literally where relevant: ${correction}`,
+			`Done When: ${doneWhen}`,
+			"Verification:",
+			...(designFile ? [`- cat ${designFile}`] : ["- cat docs/design"]),
+			"Likely Next Step: human approval",
+		];
+
+		return {
+			finalResponse: lines.join("\n"),
+			handoffTo: "@product-architect",
+			log: `DIRECT DESIGN REPAIR ROUTE\n\n${lines.join("\n")}`,
 		};
 	}
 
@@ -170,6 +247,28 @@ export class OverseerPersona {
 			: `- Do not assign the next step back to ${latestResponder}.`;
 		const explicitRepoPaths = extractRepoPathMentions(body);
 		const explicitCorrectionMentions = extractQuotedCorrectionMentions(body);
+		if (
+			shouldDirectRouteDesignRepair(
+				body,
+				_commenterPersona,
+				explicitRepoPaths,
+				explicitCorrectionMentions,
+			)
+		) {
+			logTrace("persona.overseer.directDesignRepairRoute", {
+				commenter,
+				commenterPersona: _commenterPersona,
+				body: textStats(body),
+				explicitRepoPaths,
+				explicitCorrectionMentions,
+			});
+			return this.buildDirectDesignRepairResponse(
+				body,
+				fullContext,
+				explicitRepoPaths,
+				explicitCorrectionMentions,
+			);
+		}
 		const explicitRepoPathsSection =
 			explicitRepoPaths.length > 0
 				? `\nExplicit repo paths mentioned in the latest comment:\n${explicitRepoPaths


### PR DESCRIPTION
Add a deterministic overseer fast-path for explicit human design-repair comments so the next Architect Task carries the correction literally instead of re-summarizing it through the model.

Testing:
- npx vitest run src/personas/overseer.test.ts src/utils/persona_helper.test.ts src/bots/bot_config.test.ts
- npx biome check src/personas/overseer.ts src/personas/overseer.test.ts
- npx tsc --noEmit
- npm test
