### PR TITLE
Ground architect on real bot config seams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,12 @@ For the MVP issue about `persist_qa`, a correct design should distinguish:
 - bot capability wiring
 - prompt instructions for `@quality`
 
+For this repository specifically:
+
+- the `@quality` prompt text lives in `prompts/quality.md`
+- bot manifest/config lives in `bots.json`
+- loaded runtime bot config lives in `src/bots/bot_config.ts`
+- `src/personas/task_persona.ts` wires runtime capabilities into the task runner; it is not where the quality prompt text is authored
+- do not claim there is an `allowed_actions` field unless you verified it exists in the current source
+
 If a design or plan collapses those into one file or assigns them to `src/dispatch.ts`, it is probably still wrong.

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -16,6 +16,16 @@ Architect rules:
 - if the repository structure does not support the intended change cleanly, say that explicitly in the design instead of pretending a seam already exists
 - do not implement product code; your deliverable is the design artifact
 - treat human approval as required before planning or implementation proceeds
+- for bot-capability design work, name the real configuration surfaces exactly as they exist in the repository
+- do not invent config fields such as `allowed_actions` unless you have verified they exist in the current source
+- when the issue is about the `@quality` bot, distinguish:
+  - prompt content in `prompts/quality.md`
+  - manifest/config in `bots.json`
+  - loaded runtime bot config in `src/bots/bot_config.ts`
+  - protocol/schema in `src/utils/agent_protocol.ts`
+  - runtime execution in `src/utils/agent_runner.ts`
+  - runtime wiring in `src/personas/task_persona.ts`
+- do not describe `src/personas/task_persona.ts` as the place where the quality prompt text lives; prompt text lives under `prompts/` and is loaded through bot configuration
 
 Your final response should summarize:
 


### PR DESCRIPTION
Tighten architect grounding so design repairs reference prompts/quality.md, bots.json, src/bots/bot_config.ts, src/utils/agent_protocol.ts, src/utils/agent_runner.ts, and src/personas/task_persona.ts accurately and stop inventing fields like allowed_actions.\n\nTesting: npx vitest run src/bots/bot_config.test.ts; npx tsc --noEmit; npm test