### PR TITLE
Fix human design-repair routing

### DIFF
--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -13,9 +13,11 @@ import {
 } from "./utils/handoff.js";
 import { PersistenceService } from "./utils/persistence.js";
 import {
+	extractAutomatedPersonaName,
 	extractPersonaMentions,
 	getAttribution,
 	hasExplicitPersonaMention,
+	isAutomatedPersonaComment,
 	stripMarkdownCode,
 } from "./utils/persona_helper.js";
 import { truncate } from "./utils/text.js";
@@ -82,6 +84,7 @@ function buildDirectDesignRepairIterationResult(body: string): IterationResult {
 		"Design Approval Status: needs_revision",
 		"Files To Read:",
 		...filesToRead.map((path) => `- ${path}`),
+		`Human Correction: ${correction}`,
 		`Current Step: Revise ${designFile} so it reflects the latest human correction and accurately describes the real prompt, manifest/config, protocol, runtime execution, and runtime wiring seams in this repository.`,
 		`Task Summary: Rewrite the stale sections of ${designFile} to match this correction literally where relevant: ${correction}`,
 		`Done When: ${designFile} accurately explains prompt content in prompts/quality.md, manifest/config in bots.json and src/bots/bot_config.ts, protocol/schema in src/utils/agent_protocol.ts, runtime execution in src/utils/agent_runner.ts, runtime wiring in src/personas/task_persona.ts, and does not invent fields that do not exist in the source.`,
@@ -141,7 +144,6 @@ async function run() {
 	};
 
 	const sender = eventData.sender?.login;
-	const botUser = "anicolao"; // The identity used by OVERSEER_TOKEN
 	logTrace("dispatcher.start", {
 		eventName,
 		sender,
@@ -268,8 +270,10 @@ async function run() {
 			);
 			return;
 		}
+		const automatedPersona = extractAutomatedPersonaName(body);
+		const isAutomatedComment = isAutomatedPersonaComment(body);
 		if (
-			sender !== botUser &&
+			!isAutomatedComment &&
 			activePersona === null &&
 			shouldBypassOverseerForDirectDesignRepair(body)
 		) {
@@ -290,11 +294,8 @@ async function run() {
 		}
 
 		// 1. Identify sender persona if bot
-		if (sender === botUser) {
-			const personaMatch = body.match(/I am the \*\*(.+?)\*\*/);
-			if (personaMatch) {
-				senderPersona = personaMatch[1];
-			}
+		if (automatedPersona) {
+			senderPersona = automatedPersona;
 		}
 
 		// 2. Identify target persona
@@ -359,7 +360,7 @@ async function run() {
 			};
 			// 4. Persona-Specific Bot Protection: Prevent self-triggering
 			if (
-				sender === botUser &&
+				isAutomatedComment &&
 				senderPersona === personaNameMap[executedPersona]
 			) {
 				console.log(`Ignoring self-trigger from ${executedPersona}`);

--- a/src/personas/overseer.test.ts
+++ b/src/personas/overseer.test.ts
@@ -86,6 +86,7 @@ describe("OverseerPersona direct design repair routing", () => {
 		);
 		expect(result.finalResponse).toContain("- prompts/quality.md");
 		expect(result.finalResponse).toContain("- bots.json");
+		expect(result.finalResponse).toContain("Human Correction:");
 		expect(result.finalResponse).toContain("persist_qa");
 		expect(result.finalResponse).toContain("run_shell");
 	});

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -140,6 +140,7 @@ export class OverseerPersona {
 			...(filesToRead.length > 0
 				? filesToRead.map((path) => `- ${path}`)
 				: ["- none"]),
+			`Human Correction: ${correction}`,
 			`Current Step: ${currentStep}`,
 			`Task Summary: Rewrite the stale design sections so they match this human correction literally where relevant: ${correction}`,
 			`Done When: ${doneWhen}`,

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -127,6 +127,7 @@ export class TaskPersona {
 			return [
 				"REPAIR EXECUTION NOTE:",
 				"- This is a semantic design-repair task.",
+				`- Treat the Human Correction field${taskPacket.humanCorrection ? " and the raw directed task" : ""} as a hard constraint, not as optional background context.`,
 				"- The stale file names or abstractions may not appear verbatim in the current design doc.",
 				`- After you inspect the named files once, rewrite the affected sections in ${artifact} so they name the real files, symbols, and seams from the current repository.`,
 				"- Do not spend multiple turns searching for literal stale strings.",

--- a/src/utils/persona_helper.test.ts
+++ b/src/utils/persona_helper.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	extractAutomatedPersonaName,
 	extractPersonaMentions,
 	hasExplicitPersonaMention,
+	isAutomatedPersonaComment,
 	isLimitReached,
 	stripMarkdownCode,
 } from "./persona_helper.js";
@@ -62,6 +64,24 @@ describe("extractPersonaMentions", () => {
 				].join("\n"),
 			),
 		).toEqual(["@overseer"]);
+	});
+});
+
+describe("isAutomatedPersonaComment", () => {
+	it("detects structured automated persona comments", () => {
+		const body =
+			"I am the **Overseer**, and I am responding to issue #85 from @anicolao.\n\nNext step: human review required";
+
+		expect(isAutomatedPersonaComment(body)).toBe(true);
+		expect(extractAutomatedPersonaName(body)).toBe("Overseer");
+	});
+
+	it("does not treat a human owner comment as automated without persona attribution", () => {
+		const body =
+			"@overseer I do not approve this design yet. Route it back to the architect.";
+
+		expect(isAutomatedPersonaComment(body)).toBe(false);
+		expect(extractAutomatedPersonaName(body)).toBeNull();
 	});
 });
 

--- a/src/utils/persona_helper.ts
+++ b/src/utils/persona_helper.ts
@@ -49,6 +49,17 @@ export function extractPersonaMentions(text: string): string[] {
 	return stripMarkdownCode(text).match(/@[a-z-]+/gi) ?? [];
 }
 
+export function extractAutomatedPersonaName(text: string): string | null {
+	const match = text.match(
+		/^I am the \*\*(Overseer|Product\/Architect|Planner|Developer\/Tester|Quality)\*\*, and I am responding to /,
+	);
+	return match?.[1] ?? null;
+}
+
+export function isAutomatedPersonaComment(text: string): boolean {
+	return extractAutomatedPersonaName(text) !== null;
+}
+
 export async function isLimitReached(
 	github: GitHubService,
 	owner: string,

--- a/src/utils/task_packet.test.ts
+++ b/src/utils/task_packet.test.ts
@@ -17,6 +17,7 @@ describe("task_packet", () => {
 			"Files To Read:",
 			"- src/parser.ts",
 			"- src/parser.test.ts",
+			"Human Correction: Do not invent parser-v1 classes that are not present in the repository.",
 			"Current Step: Repair the design so it matches the current parser pipeline.",
 			"Task Summary: Update the parser design doc to reflect the real implementation seams before planning further work.",
 			"Done When: docs/architecture/parser-v2.md matches the source layout and calls out open decisions for human review.",
@@ -33,6 +34,7 @@ describe("task_packet", () => {
 		expect(packet.handoffType).toBe("architect");
 		expect(packet.designFile).toBe("docs/architecture/parser-v2.md");
 		expect(packet.designApprovalStatus).toBe("needs_revision");
+		expect(packet.humanCorrection).toContain("Do not invent parser-v1 classes");
 		expect(packet.filesToRead).toEqual([
 			"docs/architecture/parser-v2.md",
 			"src/parser.ts",
@@ -119,6 +121,7 @@ describe("task_packet", () => {
 					"Design Approval Status: approved",
 					"Plan File: docs/plans/one.md",
 					"Files To Read: src/one.ts, src/two.ts",
+					"Human Correction: Keep the change limited to one token shape.",
 					"Current Step: Update the parser incrementally.",
 					"Smallest Useful Increment: Teach the parser about one new token.",
 					"Stop After: The parser accepts the new token and one focused test passes.",
@@ -140,6 +143,9 @@ describe("task_packet", () => {
 		);
 		expect(rendered).toContain(
 			"Smallest Useful Increment: Teach the parser about one new token.",
+		);
+		expect(rendered).toContain(
+			"Human Correction: Keep the change limited to one token shape.",
 		);
 		expect(rendered).toContain("Progress Evidence: git diff -- src/one.ts");
 		expect(rendered).toContain(

--- a/src/utils/task_packet.ts
+++ b/src/utils/task_packet.ts
@@ -15,6 +15,7 @@ export interface TaskPacket {
 	currentStep?: string;
 	smallestUsefulIncrement?: string;
 	stopAfter?: string;
+	humanCorrection?: string;
 	taskSummary: string;
 	doneWhen?: string;
 	progressEvidence: string[];
@@ -33,6 +34,7 @@ type StructuredTaskFields = {
 	currentStep?: string;
 	smallestUsefulIncrement?: string;
 	stopAfter?: string;
+	humanCorrection?: string;
 	taskSummary?: string;
 	doneWhen?: string;
 	progressEvidence: string[];
@@ -49,6 +51,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 			directedTask,
 			hasStructuredHandoff: false,
 			filesToRead: [],
+			humanCorrection: undefined,
 			taskSummary: directedTask,
 			progressEvidence: [],
 			verificationCommands: [],
@@ -89,6 +92,7 @@ export function parseTaskPacket(body: string): TaskPacket {
 			parsed.smallestUsefulIncrement,
 		),
 		stopAfter: normalizeOptionalValue(parsed.stopAfter),
+		humanCorrection: normalizeOptionalValue(parsed.humanCorrection),
 		taskSummary,
 		doneWhen: normalizeOptionalValue(parsed.doneWhen),
 		progressEvidence: parsed.progressEvidence
@@ -116,6 +120,7 @@ export function renderTaskPacketForPrompt(packet: TaskPacket): string {
 		`- Current Step: ${packet.currentStep || "none"}`,
 		`- Smallest Useful Increment: ${packet.smallestUsefulIncrement || "none"}`,
 		`- Stop After: ${packet.stopAfter || "none"}`,
+		`- Human Correction: ${packet.humanCorrection || "none"}`,
 		`- Task Summary: ${packet.taskSummary}`,
 		`- Done When: ${packet.doneWhen || "none"}`,
 		`- Progress Evidence: ${
@@ -181,7 +186,7 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 		}
 
 		const keyMatch = trimmed.match(
-			/^(Task ID|Design File|Design Approval Status|Plan File|Files To Read|Current Step|Smallest Useful Increment|Stop After|Task Summary|Done When|Progress Evidence|Verification|Likely Next Step):\s*(.*)$/i,
+			/^(Task ID|Design File|Design Approval Status|Plan File|Files To Read|Current Step|Smallest Useful Increment|Stop After|Human Correction|Task Summary|Done When|Progress Evidence|Verification|Likely Next Step):\s*(.*)$/i,
 		);
 		if (keyMatch) {
 			activeListKey = null;
@@ -224,6 +229,10 @@ function parseStructuredTaskFields(block: string): StructuredTaskFields {
 			if (rawKey === "stop after") {
 				result.stopAfter = rawValue.trim();
 				activeScalarKey = "stopAfter";
+				continue;
+			}
+			if (rawKey === "human correction") {
+				result.humanCorrection = rawValue.trim();
 				continue;
 			}
 			if (rawKey === "task summary") {


### PR DESCRIPTION
## Summary
- treat automated persona comments by attribution header instead of assuming the repo owner login is always the bot
- preserve direct design-repair comments from humans as explicit hard constraints in architect task packets
- surface the human correction in canonical task packets so the architect path treats it as binding

## Validation
- npx tsc --noEmit
- npm test
- npm run lint