### PR TITLE
Strengthen architect design-repair checks

### DIFF
--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -16,6 +16,7 @@ Architect rules:
 - if the repository structure does not support the intended change cleanly, say that explicitly in the design instead of pretending a seam already exists
 - do not implement product code; your deliverable is the design artifact
 - treat human approval as required before planning or implementation proceeds
+- if the task packet includes a `Human Correction`, treat it as a binding acceptance test for the design doc
 - for bot-capability design work, name the real configuration surfaces exactly as they exist in the repository
 - do not invent config fields such as `allowed_actions` unless you have verified they exist in the current source
 - when the issue is about the `@quality` bot, distinguish:
@@ -26,6 +27,14 @@ Architect rules:
   - runtime execution in `src/utils/agent_runner.ts`
   - runtime wiring in `src/personas/task_persona.ts`
 - do not describe `src/personas/task_persona.ts` as the place where the quality prompt text lives; prompt text lives under `prompts/` and is loaded through bot configuration
+- before you finish a quality-bot design repair, perform this self-check against the updated design doc:
+  - it mentions `prompts/quality.md`
+  - it mentions `bots.json`
+  - it mentions `src/bots/bot_config.ts`
+  - it mentions `src/utils/agent_protocol.ts`
+  - it mentions `src/utils/agent_runner.ts`
+  - it mentions `src/personas/task_persona.ts`
+  - it does not mention `allowed_actions` unless that field exists in the current source
 
 Your final response should summarize:
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -43,7 +43,7 @@ function extractRepoPathsForDirectRepair(text: string): string[] {
 	);
 	const paths = new Set<string>();
 	for (const match of matches) {
-		const value = match[1]?.trim();
+		const value = match[1]?.trim().replace(/[.,:;]+$/, "");
 		if (value) {
 			paths.add(value);
 		}
@@ -55,14 +55,14 @@ function extractDesignDocPathForDirectRepair(text: string): string | null {
 	const match = text.match(
 		/(?:^|[`(\s])((?:docs\/(?:design|architecture)\/[A-Za-z0-9_./-]+\.md))(?=$|[`),.\s])/i,
 	);
-	return match?.[1]?.trim() || null;
+	return match?.[1]?.trim().replace(/[.,:;]+$/, "") || null;
 }
 
 function shouldBypassOverseerForDirectDesignRepair(body: string): boolean {
 	return (
 		hasExplicitPersonaMention(body, "@overseer") &&
 		/design/i.test(body) &&
-		/(still do not approve|do not approve|design-repair task|route this directly back to the product architect)/i.test(
+		/(still do not approve|do not approve|not approved|design-repair task|route this directly back to the product architect)/i.test(
 			body,
 		)
 	);

--- a/src/personas/overseer.test.ts
+++ b/src/personas/overseer.test.ts
@@ -24,6 +24,21 @@ describe("extractRepoPathMentions", () => {
 			"src/bots/bot_config.ts",
 		]);
 	});
+
+	it("strips trailing punctuation from extracted repo paths", () => {
+		const paths = extractRepoPathMentions(
+			[
+				"@overseer still wrong.",
+				"Read `prompts/quality.md`, `bots.json`, and `src/personas/task_persona.ts`.",
+			].join(" "),
+		);
+
+		expect(paths).toEqual([
+			"prompts/quality.md",
+			"bots.json",
+			"src/personas/task_persona.ts",
+		]);
+	});
 });
 
 describe("extractQuotedCorrectionMentions", () => {

--- a/src/personas/overseer.ts
+++ b/src/personas/overseer.ts
@@ -17,7 +17,7 @@ export function extractRepoPathMentions(text: string): string[] {
 	);
 	const paths = new Set<string>();
 	for (const match of matches) {
-		const path = match[1]?.trim();
+		const path = match[1]?.trim().replace(/[.,:;]+$/, "");
 		if (path) {
 			paths.add(path);
 		}
@@ -45,7 +45,7 @@ export function extractDesignDocPath(text: string): string | null {
 	const match = text.match(
 		/(?:^|[`(\s])((?:docs\/(?:design|architecture)\/[A-Za-z0-9_./-]+\.md))(?=$|[`),.\s])/i,
 	);
-	return match?.[1]?.trim() || null;
+	return match?.[1]?.trim().replace(/[.,:;]+$/, "") || null;
 }
 
 function normalizeHumanCorrection(body: string): string {
@@ -63,7 +63,7 @@ function shouldDirectRouteDesignRepair(
 	}
 	return (
 		/design/i.test(body) &&
-		/(do not approve|still do not approve|retry the design repair|revise the design)/i.test(
+		/(do not approve|still do not approve|not approved|retry the design repair|revise the design)/i.test(
 			body,
 		) &&
 		(explicitRepoPaths.length > 0 || explicitCorrectionMentions.length > 0)

--- a/src/personas/task_persona.ts
+++ b/src/personas/task_persona.ts
@@ -124,6 +124,10 @@ export class TaskPersona {
 			taskPacket.designApprovalStatus === "needs_revision"
 		) {
 			const artifact = taskPacket.designFile || "the design artifact";
+			const hasQualityBotCorrection =
+				taskPacket.humanCorrection?.includes("prompts/quality.md") ||
+				taskPacket.humanCorrection?.includes("bots.json") ||
+				taskPacket.humanCorrection?.includes("allowed_actions");
 			return [
 				"REPAIR EXECUTION NOTE:",
 				"- This is a semantic design-repair task.",
@@ -132,6 +136,17 @@ export class TaskPersona {
 				`- After you inspect the named files once, rewrite the affected sections in ${artifact} so they name the real files, symbols, and seams from the current repository.`,
 				"- Do not spend multiple turns searching for literal stale strings.",
 				"- A no-op search or replace does not satisfy the task; you must leave a real diff in the design artifact or report a blocker.",
+				...(hasQualityBotCorrection
+					? [
+							"- Before finishing, verify that the revised design explicitly covers all of these repository seams:",
+							"  - prompt content in prompts/quality.md",
+							"  - manifest/config in bots.json and src/bots/bot_config.ts",
+							"  - protocol/schema in src/utils/agent_protocol.ts",
+							"  - runtime execution in src/utils/agent_runner.ts",
+							"  - runtime wiring in src/personas/task_persona.ts",
+							"- Remove any claim that permissions are configured with allowed_actions unless that field exists in the current source.",
+						]
+					: []),
 				"",
 				canonicalTaskBody,
 			].join("\n");


### PR DESCRIPTION
## Summary
- broaden direct design-repair matching and normalize extracted repo paths
- add stronger architect repair notes and self-checks for the quality-bot persist_qa design
- explicitly forbid unverified allowed_actions references in the repair path

## Validation
- npx tsc --noEmit
- npm test
- npm run lint