### PR TITLE
[codex] enforce edit-or-blocker after stalled reads

### DIFF
--- a/src/utils/agent_runner.test.ts
+++ b/src/utils/agent_runner.test.ts
@@ -692,6 +692,13 @@ describe("AgentRunner", () => {
 			}),
 			JSON.stringify({
 				version: AGENT_PROTOCOL_VERSION,
+				plan: ["Inspect the plan.", "Implement the change."],
+				next_step: "Inspect another file.",
+				actions: [{ type: "run_ro_shell", command: "cat src/other.ts" }],
+				task_status: "in_progress",
+			}),
+			JSON.stringify({
+				version: AGENT_PROTOCOL_VERSION,
 				plan: ["Return control."],
 				next_step: "Return control.",
 				actions: [],
@@ -727,7 +734,7 @@ describe("AgentRunner", () => {
 			gemini as never,
 			"System instruction",
 			"Initial message",
-			5,
+			6,
 			{
 				shellAccess: "read_only",
 				maxActionsPerTurn: 1,
@@ -738,6 +745,13 @@ describe("AgentRunner", () => {
 			sentMessages.some((message) =>
 				message.includes(
 					"consecutive turns on read-only inspection without editing",
+				),
+			),
+		).toBe(true);
+		expect(
+			sentMessages.some((message) =>
+				message.includes(
+					'Your next response must either make a targeted repository edit with replace_in_file or run_shell, or finish with task_status "done" and a blocker summary for Overseer.',
 				),
 			),
 		).toBe(true);
@@ -787,7 +801,7 @@ describe("AgentRunner", () => {
 		);
 
 		expect(result.finalResponse).toContain(
-			"Stopped after repeated no-progress loops",
+			"Stopped after repeated invalid responses without adapting",
 		);
 		expect(
 			sentMessages.some((message) => message.includes("LOOP DETECTED:")),

--- a/src/utils/agent_runner.ts
+++ b/src/utils/agent_runner.ts
@@ -77,6 +77,8 @@ interface RunnerProgressState {
 	repeatedCycleCount: number;
 	loopRepairsIssued: number;
 	consecutiveReadOnlyTurnsWithoutWrite: number;
+	lastProtocolError?: string;
+	consecutiveProtocolErrorCount: number;
 }
 
 export class AgentRunner {
@@ -125,6 +127,7 @@ export class AgentRunner {
 			repeatedCycleCount: 0,
 			loopRepairsIssued: 0,
 			consecutiveReadOnlyTurnsWithoutWrite: 0,
+			consecutiveProtocolErrorCount: 0,
 		};
 
 		while (iteration < maxIterations) {
@@ -154,14 +157,22 @@ export class AgentRunner {
 			try {
 				parsedResponse = parseAgentProtocolResponse(responseText);
 			} catch (error) {
+				const errorMessage =
+					error instanceof Error ? error.message : String(error);
 				logTrace("agent.iteration.protocolError", {
 					iteration,
-					error: error instanceof Error ? error.message : String(error),
+					error: errorMessage,
 				});
-				currentMessage = buildProtocolRepairMessage(
-					error instanceof Error ? error.message : String(error),
+				const abortResult = this.handleProtocolError(
+					progressState,
+					errorMessage,
 					responseText,
+					options,
 				);
+				if (abortResult) {
+					return abortResult;
+				}
+				currentMessage = buildProtocolRepairMessage(errorMessage, responseText);
 				continue;
 			}
 
@@ -187,7 +198,41 @@ export class AgentRunner {
 					error,
 					maxActionsPerTurn,
 				});
+				const abortResult = this.handleProtocolError(
+					progressState,
+					error,
+					responseText,
+					options,
+				);
+				if (abortResult) {
+					return abortResult;
+				}
 				currentMessage = buildProtocolRepairMessage(error, responseText);
+				continue;
+			}
+
+			const readOnlyStallError = this.validateReadOnlyStallResponse(
+				progressState,
+				parsedResponse,
+			);
+			if (readOnlyStallError) {
+				logTrace("agent.iteration.protocolError", {
+					iteration,
+					error: readOnlyStallError,
+				});
+				const abortResult = this.handleProtocolError(
+					progressState,
+					readOnlyStallError,
+					responseText,
+					options,
+				);
+				if (abortResult) {
+					return abortResult;
+				}
+				currentMessage = buildProtocolRepairMessage(
+					readOnlyStallError,
+					responseText,
+				);
 				continue;
 			}
 
@@ -199,6 +244,15 @@ export class AgentRunner {
 						iteration,
 						error,
 					});
+					const abortResult = this.handleProtocolError(
+						progressState,
+						error,
+						responseText,
+						options,
+					);
+					if (abortResult) {
+						return abortResult;
+					}
 					currentMessage = buildProtocolRepairMessage(error, responseText);
 					continue;
 				}
@@ -211,6 +265,15 @@ export class AgentRunner {
 						iteration,
 						error: doneValidationError,
 					});
+					const abortResult = this.handleProtocolError(
+						progressState,
+						doneValidationError,
+						responseText,
+						options,
+					);
+					if (abortResult) {
+						return abortResult;
+					}
 					currentMessage = buildProtocolRepairMessage(
 						doneValidationError,
 						responseText,
@@ -228,6 +291,8 @@ export class AgentRunner {
 				parsedResponse.protocol.actions,
 				options,
 			);
+			progressState.lastProtocolError = undefined;
+			progressState.consecutiveProtocolErrorCount = 0;
 			this.updateProgressState(progressState, actionExecution.executedActions);
 			const actionOutput = actionExecution.output;
 			const actionSummary = actionExecution.summary;
@@ -551,6 +616,63 @@ export class AgentRunner {
 		}
 
 		return null;
+	}
+
+	private handleProtocolError(
+		state: RunnerProgressState,
+		error: string,
+		_responseText: string,
+		options: AgentRunnerOptions,
+	): IterationResult | null {
+		if (state.lastProtocolError === error) {
+			state.consecutiveProtocolErrorCount += 1;
+		} else {
+			state.lastProtocolError = error;
+			state.consecutiveProtocolErrorCount = 1;
+		}
+
+		if (state.consecutiveProtocolErrorCount < 3) {
+			return null;
+		}
+
+		logTrace("agent.loop.abortedForRepeatedProtocolErrors", {
+			error,
+			consecutiveProtocolErrorCount: state.consecutiveProtocolErrorCount,
+		});
+		return {
+			finalResponse:
+				"Stopped after repeated invalid responses without adapting. The bot needs a revised task packet or human intervention before continuing.",
+			handoffTo: options.loopAbortHandoffTo,
+			log: this.sessionLog,
+		};
+	}
+
+	private validateReadOnlyStallResponse(
+		state: RunnerProgressState,
+		parsedResponse: ParsedAgentProtocolResponse,
+	): string | null {
+		if (state.usedWriteAction) {
+			return null;
+		}
+
+		if (state.consecutiveReadOnlyTurnsWithoutWrite < 2) {
+			return null;
+		}
+
+		if (parsedResponse.protocol.task_status === "done") {
+			return null;
+		}
+
+		const hasOnlyReadOnlyActions =
+			parsedResponse.protocol.actions.length > 0 &&
+			parsedResponse.protocol.actions.every(
+				(action) => action.type === "run_ro_shell",
+			);
+		if (!hasOnlyReadOnlyActions) {
+			return null;
+		}
+
+		return `You have already spent ${state.consecutiveReadOnlyTurnsWithoutWrite} consecutive turns on read-only inspection without editing. Your next response must either make a targeted repository edit with replace_in_file or run_shell, or finish with task_status "done" and a blocker summary for Overseer.`;
 	}
 
 	private buildProgressReminder(


### PR DESCRIPTION
## What changed
- enforce a hard edit-or-blocker rule after two consecutive successful read-only turns with no writes
- abort after repeated identical protocol-repair failures instead of consuming the full iteration budget
- cover the new runner behavior in tests

## Why
Developer runs can still stall on narrow implementation steps by repeatedly rereading files after the reminder fires. This turns that reminder into an enforced contract and stops bad recovery loops earlier.

## Impact
- task bots are forced to either edit, or hand back a blocker, once inspection has clearly stalled
- repeated invalid protocol responses no longer burn the entire max-iteration budget

## Validation
- `npx vitest run src/utils/agent_runner.test.ts`
- `npx tsc --noEmit`
- `npm test`
