### PR TITLE
[codex] ground persist_qa in issue semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,5 +56,9 @@ For this repository specifically:
 - loaded runtime bot config lives in `src/bots/bot_config.ts`
 - `src/personas/task_persona.ts` wires runtime capabilities into the task runner; it is not where the quality prompt text is authored
 - do not claim there is an `allowed_actions` field unless you verified it exists in the current source
+- preserve the user-requested action semantics:
+  - `run_shell` is what writes or edits the QA document files under `docs/qa/`
+  - `persist_qa` is what persists those existing `docs/qa/` changes
+  - do not redesign `persist_qa` as a second file-writing action with its own content payload unless the issue explicitly asks for that
 
 If a design or plan collapses those into one file or assigns them to `src/dispatch.ts`, it is probably still wrong.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -10,6 +10,7 @@ Planner rules:
 - each plan should stay anchored to the approved design file and the current code layout
 - every implementation step should name real repository files that exist on the current branch, unless the step is explicitly about creating a new file
 - if the design references nonexistent files or made-up seams, stop and hand the task back for design repair instead of translating that drift into a developer task
+- preserve the approved design's action semantics; if the issue says `run_shell` writes files and another action persists them, do not collapse those responsibilities into one implementation step
 
 Your final response should summarize:
 

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -26,6 +26,8 @@ Architect rules:
   - protocol/schema in `src/utils/agent_protocol.ts`
   - runtime execution in `src/utils/agent_runner.ts`
   - runtime wiring in `src/personas/task_persona.ts`
+- preserve the requested action semantics from the issue body; for the `persist_qa` MVP, `run_shell` writes the QA files and `persist_qa` persists those existing `docs/qa/` changes
+- do not redesign `persist_qa` as a duplicate file-writing payload action unless the issue explicitly asks for that behavior
 - do not describe `src/personas/task_persona.ts` as the place where the quality prompt text lives; prompt text lives under `prompts/` and is loaded through bot configuration
 - before you finish a quality-bot design repair, perform this self-check against the updated design doc:
   - it mentions `prompts/quality.md`
@@ -35,6 +37,7 @@ Architect rules:
   - it mentions `src/utils/agent_runner.ts`
   - it mentions `src/personas/task_persona.ts`
   - it does not mention `allowed_actions` unless that field exists in the current source
+  - it keeps `run_shell` and `persist_qa` as separate steps instead of collapsing both behaviors into `persist_qa`
 
 Your final response should summarize:
 


### PR DESCRIPTION
## What changed
- added repo guidance that preserves the requested `run_shell` then `persist_qa` behavior for the MVP issue
- tightened architect and planner prompts so they do not redesign `persist_qa` into a second file-writing payload action

## Why
The approved design drifted away from the issue body: it treated `persist_qa` as the action that writes file contents, even though the issue explicitly says `run_shell` writes the QA documents and `persist_qa` stores those existing changes.

## Impact
Design repair and planning should stay aligned with the actual feature semantics instead of handing the developer the wrong abstraction.

## Validation
- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
