### PR TITLE
Reuse existing plans after design approval

### DIFF
--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -96,5 +96,6 @@ Requirements for Overseer handoffs:
 - keep developer tasks narrow enough that Overseer can inspect the result and decide the next step
 - list only the files the worker actually needs first; avoid broad repo scavenger hunts
 - if the latest responder claims a file changed, inspect that file before delegating follow-up work
+- if an approved design already has a plan file on the branch, include that plan file in the next planner handoff's `Files To Read` and ask the planner to validate or update it instead of silently discarding it
 
 Keep your final summary to at most three sentences before the required delegation suffix.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -11,6 +11,7 @@ Planner rules:
 - every implementation step should name real repository files that exist on the current branch, unless the step is explicitly about creating a new file
 - if the design references nonexistent files or made-up seams, stop and hand the task back for design repair instead of translating that drift into a developer task
 - preserve the approved design's action semantics; if the issue says `run_shell` writes files and another action persists them, do not collapse those responsibilities into one implementation step
+- if the task packet already names a `Plan File` that exists, read it first and treat your job as validating or updating that existing plan rather than replacing it blindly
 
 Your final response should summarize:
 

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -121,8 +121,21 @@ function buildDirectDesignApprovalIterationResult(
 	const designFile =
 		extractDesignDocPathForDirectRepair(body) || "docs/design/persist-qa.md";
 	const planFile = buildPlanPathFromDesignFile(designFile);
+	const planExists = fs.existsSync(planFile);
+	const filesToRead = planExists ? [designFile, planFile] : [designFile];
+	const currentStep = planExists
+		? `Validate or update the existing implementation plan in ${planFile} for the approved design.`
+		: "Create the implementation plan for the approved design.";
+	const taskSummary = planExists
+		? `Review ${planFile} against ${designFile}, keep the existing plan if it is still valid, and update it only where the approved design now requires changes.`
+		: `Decompose ${designFile} into small implementation increments that can be delegated one at a time.`;
+	const doneWhen = planExists
+		? `${planFile} accurately reflects the approved design and describes the implementation steps needed to realize it.`
+		: `${planFile} exists and describes the implementation steps needed to realize the approved design.`;
 	const finalResponse = [
-		"The human has explicitly approved the current design. I am routing the approved artifact directly to the Planner.",
+		planExists
+			? "The human has explicitly approved the current design. I am routing the approved design and the existing plan artifact directly to the Planner for validation or update."
+			: "The human has explicitly approved the current design. I am routing the approved artifact directly to the Planner.",
 		"",
 		"Planner Task:",
 		"Task ID: MVP validation: persist_qa end-to-end",
@@ -130,10 +143,10 @@ function buildDirectDesignApprovalIterationResult(
 		"Design Approval Status: approved",
 		`Plan File: ${planFile}`,
 		"Files To Read:",
-		`- ${designFile}`,
-		"Current Step: Create the implementation plan for the approved design.",
-		`Task Summary: Decompose ${designFile} into small implementation increments that can be delegated one at a time.`,
-		`Done When: ${planFile} exists and describes the implementation steps needed to realize the approved design.`,
+		...filesToRead.map((path) => `- ${path}`),
+		`Current Step: ${currentStep}`,
+		`Task Summary: ${taskSummary}`,
+		`Done When: ${doneWhen}`,
 		"Verification:",
 		`- cat ${planFile}`,
 		"Likely Next Step: Delegate the first implementation increment to @developer-tester.",


### PR DESCRIPTION
## Summary
- reuse an existing plan artifact when a human re-approves a design on an issue branch
- include the plan file in direct planner handoffs when it already exists
- align overseer and planner prompts with validating/updating existing plans instead of recreating them

## Testing
- npx tsc --noEmit
- npm test