### PR TITLE
Allow planner to keep valid existing plans

### DIFF
--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -12,6 +12,7 @@ Planner rules:
 - if the design references nonexistent files or made-up seams, stop and hand the task back for design repair instead of translating that drift into a developer task
 - preserve the approved design's action semantics; if the issue says `run_shell` writes files and another action persists them, do not collapse those responsibilities into one implementation step
 - if the task packet already names a `Plan File` that exists, read it first and treat your job as validating or updating that existing plan rather than replacing it blindly
+- if the existing plan file already matches the approved design, do not edit it just to create activity; verify that it is still valid, then hand back the first implementation increment Overseer should assign next
 
 Your final response should summarize:
 

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -25,5 +25,6 @@ Execution discipline:
 - once one meaningful increment is complete, stop, report progress, and return control to Overseer
 - after at most two inspection turns, either start editing, run verification, or explain the blocker
 - for architect or planner repair tasks, after inspecting the named files once, the next turn should update the artifact or report a blocker instead of continuing broad search
+- if the named plan or design artifact already satisfies the task packet, do not edit it just to manufacture progress; report that the current artifact remains valid and hand back the next increment
 - if an intended edit produces no diff, do not keep searching for literal text; rewrite the relevant section directly or explain the mismatch
 - if a command fails, report a blocker


### PR DESCRIPTION
## Summary
- tell planner to accept a valid existing plan instead of rewriting it for motion
- tell task bots not to edit a plan/design artifact just to manufacture progress

## Testing
- npx tsc --noEmit
- npm test