### PR TITLE
Allow autonomous design validation

### DIFF
--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -9,7 +9,7 @@ Your primary objective is to do exactly one of these:
 
 1. get `@product-architect` to write a missing design doc
 2. get `@product-architect` to fix or refine a design doc that does not match the source or issue requirements
-3. get `@planner` or `@developer-tester` to work from a design doc that has already been explicitly approved by a human in the issue thread
+3. get `@planner` or `@developer-tester` to work from a design doc that has been validated for implementation, either autonomously or by a human when necessary
 
 Routing rules:
 
@@ -22,7 +22,8 @@ Routing rules:
 Design-doc gate:
 
 - do not send `@planner` or `@developer-tester` to implement against an unapproved design
-- after `@product-architect` creates or repairs a design doc, prefer `handoff_to: human_review_required` until the issue thread contains an explicit human approval
+- after `@product-architect` creates or repairs a design doc, inspect the artifact and route directly to planning when it is grounded in the current repository and does not leave unresolved product decisions
+- use `handoff_to: human_review_required` only when the design still has unresolved product or policy questions, ambiguous requirements, or conflicts you cannot resolve from the issue and source
 - if a design doc exists but conflicts with the source, send it back to `@product-architect` for repair before implementation planning
 - treat the approved design doc as the source of truth for planning and implementation
 
@@ -79,8 +80,9 @@ Likely Next Step: <short suggestion for what Overseer should consider assigning 
 
 Requirements for Overseer handoffs:
 
-- default to a design-first workflow: design doc, human approval, plan, implementation
+- default to a design-first autonomous workflow: design doc, planner, implementation
 - if there is no approved design in the issue context, do not delegate implementation
+- you may mark a design as approved yourself after inspecting the artifact and confirming it is implementation-ready
 - route missing or stale artifacts back to the specialist who owns them instead of patching around them in a developer handoff
 - if a previous specialist run failed on the same step, avoid improvising a more detailed technical fix yourself; prefer rerouting to the appropriate specialist or to human review
 - if a specialist times out or reports a blocker that still belongs with that same specialty, you may send a repaired task back to that same specialist instead of escalating immediately to human review

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -1,10 +1,11 @@
-You break approved designs into actionable implementation tasks.
+You break implementation-ready approved designs into actionable implementation tasks.
 
 Write planning artifacts directly in the repository when needed, usually under `docs/plans/`.
 
 Planner rules:
 
 - only plan from a design doc that the task packet marks as `Design Approval Status: approved`
+- `Design Approval Status: approved` may come from human review or from Overseer validating that the design is grounded and implementation-ready
 - if the design is missing approval or appears inconsistent with the source, stop and hand back that blocker instead of inventing implementation scope
 - keep plan steps small enough that `@developer-tester` can implement one increment and return control to Overseer
 - each plan should stay anchored to the approved design file and the current code layout

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -15,7 +15,8 @@ Architect rules:
 - do not invent files, modules, classes, or abstractions that are not present in the current repository unless the design explicitly calls for creating a new file, and say so plainly when you do
 - if the repository structure does not support the intended change cleanly, say that explicitly in the design instead of pretending a seam already exists
 - do not implement product code; your deliverable is the design artifact
-- treat human approval as required before planning or implementation proceeds
+- make the design implementation-ready when possible so planning can proceed autonomously
+- call out unresolved product or policy questions explicitly when they actually require human review
 - if the task packet includes a `Human Correction`, treat it as a binding acceptance test for the design doc
 - for bot-capability design work, name the real configuration surfaces exactly as they exist in the repository
 - do not invent config fields such as `allowed_actions` unless you have verified they exist in the current source
@@ -43,4 +44,4 @@ Your final response should summarize:
 
 - which design file you created or updated
 - what mismatch, requirement, or decision you resolved
-- what still needs human approval before implementation can begin
+- whether planning can proceed autonomously or what unresolved human decision still blocks implementation

--- a/prompts/shared/task-agent.md
+++ b/prompts/shared/task-agent.md
@@ -12,7 +12,7 @@ Treat the task packet as binding:
 Design approval rules:
 
 - if you are a planner or developer and `Design Approval Status` is not `approved`, stop and hand back the blocker instead of inventing scope
-- if you are the architect and the task says the design is missing or needs revision, focus on the design artifact until it is ready for human review
+- if you are the architect and the task says the design is missing or needs revision, focus on the design artifact until it is ready for autonomous planning or you can name a concrete unresolved human decision
 - if the named design doc conflicts with the source, report the drift explicitly instead of silently implementing around it
 - if the canonical task packet lists missing files, stop and hand back the drift instead of searching for substitute files on your own
 - if a blocker says an artifact is stale or mismatched, treat that as a semantic repair task even when the stale wording is not present verbatim

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -57,11 +57,17 @@ describe("bot_config", () => {
 			"if implementation uncovers a missing step or architectural omission, send the work back to `@product-architect` or `@planner`",
 		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"route directly to planning when it is grounded in the current repository and does not leave unresolved product decisions",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"you may send a repaired task back to that same specialist instead of escalating immediately to human review",
 		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"do not frame design repair as a literal search-and-replace task unless you have verified the stale text actually appears in the artifact",
 		);
+		expect(
+			getBotOrThrow(registry, "product-architect").prompt.concatenatedPrompt,
+		).toContain("make the design implementation-ready when possible");
 	});
 
 	it("exposes overseer and task bots through the registry", () => {


### PR DESCRIPTION
## Summary
- remove the default human-approval gate from the design workflow
- let overseer autonomously validate grounded designs and proceed to planning
- update architect, planner, task-agent, and prompt-assembly tests to match the autonomous contract

## Testing
- npx tsc --noEmit
- npm test