### PR TITLE
Ignore workflow noise during persistence

### DIFF
--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseNullDelimitedPaths } from "./persistence.js";
+import {
+	isIgnoredPersistencePath,
+	parseNullDelimitedPaths,
+} from "./persistence.js";
 
 describe("parseNullDelimitedPaths", () => {
 	it("preserves complete filenames from null-delimited git output", () => {
@@ -17,5 +20,18 @@ describe("parseNullDelimitedPaths", () => {
 		const output = "\0docs/plans/plan.md\0docs/plans/plan.md\0\0";
 
 		expect(parseNullDelimitedPaths(output)).toEqual(["docs/plans/plan.md"]);
+	});
+});
+
+describe("isIgnoredPersistencePath", () => {
+	it("ignores workflow noise paths that should not be persisted", () => {
+		expect(isIgnoredPersistencePath("flake.lock")).toBe(true);
+		expect(
+			isIgnoredPersistencePath(".backstop/persistence-backstop/git-status.txt"),
+		).toBe(true);
+		expect(isIgnoredPersistencePath("session_architect.log")).toBe(true);
+		expect(isIgnoredPersistencePath("docs/design/persist-qa-mvp.md")).toBe(
+			false,
+		);
 	});
 });

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -29,6 +29,14 @@ export function parseNullDelimitedPaths(output: string): string[] {
 	return Array.from(new Set(output.split("\0").filter(Boolean)));
 }
 
+export function isIgnoredPersistencePath(path: string): boolean {
+	return (
+		path === "flake.lock" ||
+		path.startsWith(".backstop/") ||
+		/^session_.*\.log$/.test(path)
+	);
+}
+
 export class PersistenceService {
 	async ensureIssueBranch(
 		issueNumber: number,
@@ -289,6 +297,7 @@ export class PersistenceService {
 				"--",
 				".",
 				":(glob,exclude).backstop/**",
+				":(exclude)flake.lock",
 				":(glob,exclude)session_*.log",
 			],
 			"persistence.stage",
@@ -302,12 +311,12 @@ export class PersistenceService {
 			"persistence.stagedChangedPaths",
 		);
 		return parseNullDelimitedPaths(result.stdout).filter(
-			(path) => !this.isIgnoredPath(path),
+			(path) => !isIgnoredPersistencePath(path),
 		);
 	}
 
 	private isIgnoredPath(path: string): boolean {
-		return path.startsWith(".backstop/") || /^session_.*\.log$/.test(path);
+		return isIgnoredPersistencePath(path);
 	}
 
 	private async remoteBranchExists(branchName: string): Promise<boolean> {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,7 @@
 import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    exclude: [...configDefaults.exclude, ".artifacts/**"],
-  },
+	test: {
+		exclude: [...configDefaults.exclude, ".artifacts/**", "dist/**"],
+	},
 });


### PR DESCRIPTION
## Summary
- ignore `dist/**` during Vitest discovery so issue branches do not fail on stale built test files
- keep `persist_work` from staging workflow-generated `flake.lock`
- add regression coverage for ignored persistence paths

## Testing
- npx tsc --noEmit
- npm test
- npx biome check src/utils/persistence.ts src/utils/persistence.test.ts vitest.config.js