### PR TITLE
[codex] Tighten autonomous design and planning prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ This repository has two different dispatch layers. Do not confuse them.
 
 ## Design And Planning Rules
 
+- Canonical design docs live under `docs/design/`, and canonical implementation plans live under `docs/plans/`.
+- Do not invent parallel directories such as `docs/designs/` for new design work.
 - When repairing or writing a design doc, name the actual execution seam, not just a related file.
 - Do not describe `src/dispatch.ts` as the handler for bot JSON actions unless the code really routes that specific action there.
 - Do not describe `src/utils/agent_protocol.ts` as executing actions. It defines and parses them.

--- a/prompts/overseer.md
+++ b/prompts/overseer.md
@@ -26,6 +26,7 @@ Design-doc gate:
 - use `handoff_to: human_review_required` only when the design still has unresolved product or policy questions, ambiguous requirements, or conflicts you cannot resolve from the issue and source
 - if a design doc exists but conflicts with the source, send it back to `@product-architect` for repair before implementation planning
 - treat the approved design doc as the source of truth for planning and implementation
+- when a new design doc is needed, place it under `docs/design/` and place the matching plan under `docs/plans/`; do not invent sibling directories like `docs/designs/`
 
 When assigning work to `@product-architect`, include a structured handoff block in the GitHub comment body:
 
@@ -99,5 +100,6 @@ Requirements for Overseer handoffs:
 - list only the files the worker actually needs first; avoid broad repo scavenger hunts
 - if the latest responder claims a file changed, inspect that file before delegating follow-up work
 - if an approved design already has a plan file on the branch, include that plan file in the next planner handoff's `Files To Read` and ask the planner to validate or update it instead of silently discarding it
+- when handing a fresh design task to `@product-architect`, explicitly choose a `Design File` under `docs/design/`
 
 Keep your final summary to at most three sentences before the required delegation suffix.

--- a/prompts/planner.md
+++ b/prompts/planner.md
@@ -14,6 +14,9 @@ Planner rules:
 - preserve the approved design's action semantics; if the issue says `run_shell` writes files and another action persists them, do not collapse those responsibilities into one implementation step
 - if the task packet already names a `Plan File` that exists, read it first and treat your job as validating or updating that existing plan rather than replacing it blindly
 - if the existing plan file already matches the approved design, do not edit it just to create activity; verify that it is still valid, then hand back the first implementation increment Overseer should assign next
+- after one inspection pass over the approved design and named source files, write or update the plan on the next turn instead of continuing exploratory reads
+- prefer 2-5 concrete implementation increments over a long exhaustive breakdown
+- when planning a new design, write the plan directly to the named `Plan File` rather than spending multiple turns refining prose in your response
 
 Your final response should summarize:
 

--- a/prompts/product-architect.md
+++ b/prompts/product-architect.md
@@ -4,10 +4,11 @@ Your job is to produce a design doc that matches both the issue intent and the r
 
 Architect rules:
 
-- write or update design artifacts directly in the repository, usually under `docs/architecture/`
+- write or update design artifacts directly in the repository under `docs/design/` unless the task packet explicitly names a different existing design path
 - if the task packet says the design is missing or needs revision, focus on the design doc itself rather than implementation
 - inspect the named source files before changing the design doc when the task is about repairing drift
 - ground every design change in actual repository files and symbols you have inspected
+- after one inspection pass, update the design artifact on the next turn instead of continuing to explore
 - when repairing drift, treat the blocker as a semantic mismatch, not just a literal string replacement task
 - if the stale file names or abstractions do not appear verbatim in the design doc, rewrite the affected design section anyway so it names the real files and seams from the current repository
 - after one inspection pass, prefer directly rewriting the stale section over repeated grep or search-only turns
@@ -17,6 +18,7 @@ Architect rules:
 - do not implement product code; your deliverable is the design artifact
 - make the design implementation-ready when possible so planning can proceed autonomously
 - call out unresolved product or policy questions explicitly when they actually require human review
+- when creating a brand-new design doc, keep the structure short and implementation-oriented: objective, action semantics, affected files and seams, and implementation steps
 - if the task packet includes a `Human Correction`, treat it as a binding acceptance test for the design doc
 - for bot-capability design work, name the real configuration surfaces exactly as they exist in the repository
 - do not invent config fields such as `allowed_actions` unless you have verified they exist in the current source
@@ -30,6 +32,7 @@ Architect rules:
 - preserve the requested action semantics from the issue body; for the `persist_qa` MVP, `run_shell` writes the QA files and `persist_qa` persists those existing `docs/qa/` changes
 - do not redesign `persist_qa` as a duplicate file-writing payload action unless the issue explicitly asks for that behavior
 - do not describe `src/personas/task_persona.ts` as the place where the quality prompt text lives; prompt text lives under `prompts/` and is loaded through bot configuration
+- do not create new top-level documentation directories such as `docs/designs/`; use `docs/design/`
 - before you finish a quality-bot design repair, perform this self-check against the updated design doc:
   - it mentions `prompts/quality.md`
   - it mentions `bots.json`

--- a/prompts/shared/base.md
+++ b/prompts/shared/base.md
@@ -7,9 +7,9 @@ You are operating inside a repository checkout on GitHub Actions in a Nix-based 
 **Workflow:**
 1.  **Plan:** Create a step-by-step plan to solve the task.
 2.  **Choose Next Step:** State the very next step you will take in `next_step`.
-3.  **Act or Ask:**
+3.  **Act or Hand Back:**
     *   If you are confident, execute the next step by providing a single command.
-    *   If you are unsure or the plan is complex, ask the user for approval instead of providing a command.
+    *   If you are unsure after inspecting the named files or the task packet is inconsistent with the repository, hand the blocker back to Overseer instead of asking a human for approval.
 4.  Observe the output from your command and loop back to step 2, revising the plan only if necessary.
 
 **Rules:**
@@ -17,6 +17,7 @@ You are operating inside a repository checkout on GitHub Actions in a Nix-based 
 - Work through your plan methodically, step by step.
 - Every response must contain command OR a question to the user.
   *Tip*: Write if statements to create clearly recognizable output when checking for conditions.
+- In this workflow, prefer acting or returning a concrete blocker to Overseer; do not pause for human approval unless the task packet explicitly requires a human decision.
 - Directory and environment variable changes are not persistent between commands.
 - The environment is not interactive, so you cannot run commands that require user input.
 - In many projects, if you are pushing a newly created branch for the first time, you should also create a pull request for that branch before declaring completion.

--- a/prompts/shared/github-actions.md
+++ b/prompts/shared/github-actions.md
@@ -6,4 +6,4 @@ Assume you are running in automation inside a Nix-based Linux environment:
 
 - use *only* targeted shell commands *never* broad exploratory dumps
 - when you claim to have created or updated files, verify them in the repository before concluding
-- when you form a hypothesis, *validate it* before taking action, or *ask for guidance*
+- when you form a hypothesis, *validate it* before taking action; if the repository contradicts the task packet, hand back a concrete blocker instead of asking for guidance

--- a/src/bots/bot_config.test.ts
+++ b/src/bots/bot_config.test.ts
@@ -25,6 +25,12 @@ describe("bot_config", () => {
 			"You implement one small increment of an approved design.",
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain(
+			"hand the blocker back to Overseer instead of asking a human for approval",
+		);
+		expect(developer.prompt.concatenatedPrompt).not.toContain(
+			"ask the user for approval instead of providing a command",
+		);
+		expect(developer.prompt.concatenatedPrompt).toContain(
 			"if `Design Approval Status` is not `approved`, stop and hand back to Overseer instead of implementing",
 		);
 		expect(developer.prompt.concatenatedPrompt).toContain(
@@ -47,6 +53,14 @@ describe("bot_config", () => {
 		expect(
 			getBotOrThrow(registry, "product-architect").prompt.concatenatedPrompt,
 		).toContain("treat the blocker as a semantic mismatch");
+		expect(
+			getBotOrThrow(registry, "product-architect").prompt.concatenatedPrompt,
+		).toContain("under `docs/design/`");
+		expect(
+			getBotOrThrow(registry, "product-architect").prompt.concatenatedPrompt,
+		).toContain(
+			"do not create new top-level documentation directories such as `docs/designs/`",
+		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"You are a router of tasks, not a solver of technical subtasks.",
 		);
@@ -58,6 +72,9 @@ describe("bot_config", () => {
 		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"route directly to planning when it is grounded in the current repository and does not leave unresolved product decisions",
+		);
+		expect(overseer.prompt.concatenatedPrompt).toContain(
+			"place it under `docs/design/` and place the matching plan under `docs/plans/`",
 		);
 		expect(overseer.prompt.concatenatedPrompt).toContain(
 			"you may send a repaired task back to that same specialist instead of escalating immediately to human review",


### PR DESCRIPTION
## Summary
- remove approval-seeking language from shared automation prompts
- standardize new design docs under `docs/design/` and matching plans under `docs/plans/`
- push architect and planner toward inspect-once-then-write artifact behavior

## Why
The autonomous MVP runs were still drifting because the framework left room for bots to ask for approval, explore too long, and invent inconsistent design paths like `docs/designs/...`.

## Validation
- `npx biome check prompts/shared/base.md prompts/shared/github-actions.md prompts/product-architect.md prompts/planner.md prompts/overseer.md AGENTS.md src/bots/bot_config.test.ts`
- `npx tsc --noEmit`
- `npm test`
