### PR TITLE
[codex] Always validate architect artifacts

### DIFF
--- a/src/dispatch.test.ts
+++ b/src/dispatch.test.ts
@@ -4,7 +4,7 @@ import {
 	buildPlanPathFromDesignFile,
 	extractDesignDocPathForDirectRepair,
 	findPersistQaDesignValidationFindings,
-	shouldBypassOverseerForArchitectPlanningReady,
+	shouldBypassOverseerForArchitectDesignReview,
 } from "./dispatch.js";
 
 describe("dispatch direct architect routing", () => {
@@ -23,7 +23,7 @@ describe("dispatch direct architect routing", () => {
 			"docs/plans/persist-qa.md",
 		);
 		expect(
-			shouldBypassOverseerForArchitectPlanningReady(body, "Product/Architect"),
+			shouldBypassOverseerForArchitectDesignReview(body, "Product/Architect"),
 		).toBe(true);
 
 		const result = buildDirectArchitectPlanningIterationResult(body);
@@ -41,10 +41,10 @@ describe("dispatch direct architect routing", () => {
 		const body =
 			"Planning can proceed autonomously. `docs/design/persist-qa.md`";
 
-		expect(
-			shouldBypassOverseerForArchitectPlanningReady(body, "Overseer"),
-		).toBe(false);
-		expect(shouldBypassOverseerForArchitectPlanningReady(body, undefined)).toBe(
+		expect(shouldBypassOverseerForArchitectDesignReview(body, "Overseer")).toBe(
+			false,
+		);
+		expect(shouldBypassOverseerForArchitectDesignReview(body, undefined)).toBe(
 			false,
 		);
 	});

--- a/src/dispatch.ts
+++ b/src/dispatch.ts
@@ -161,15 +161,12 @@ export function shouldBypassOverseerForApprovedDesign(body: string): boolean {
 	);
 }
 
-export function shouldBypassOverseerForArchitectPlanningReady(
+export function shouldBypassOverseerForArchitectDesignReview(
 	body: string,
 	automatedPersona: string | undefined,
 ): boolean {
 	return (
 		automatedPersona === "Product/Architect" &&
-		/planning can proceed autonomously|implementation-ready|ready for review and planning|ready for planning/i.test(
-			body,
-		) &&
 		Boolean(extractDesignDocPathForDirectRepair(body))
 	);
 }
@@ -543,7 +540,7 @@ async function run() {
 		if (
 			isAutomatedComment &&
 			activePersona === null &&
-			shouldBypassOverseerForArchitectPlanningReady(
+			shouldBypassOverseerForArchitectDesignReview(
 				body,
 				automatedPersona ?? undefined,
 			)


### PR DESCRIPTION
## Summary
- treat any Product/Architect comment with a design file as a candidate for immediate validation
- stop relying on a narrow phrase match before checking the design artifact
- keep invalid architect artifacts out of planning regardless of wording

## Why
The architect validator existed, but it only ran when the comment said the right phrase. Bad designs could still slip through to Overseer approval if the architect used different wording.

## Validation
- `npx biome check src/dispatch.ts src/dispatch.test.ts`
- `npx tsc --noEmit`
- `npm test`
